### PR TITLE
Formalise Errors

### DIFF
--- a/configdns-v1/errors.go
+++ b/configdns-v1/errors.go
@@ -19,14 +19,14 @@ type ZoneError struct {
 }
 
 func (e *ZoneError) Network() bool {
-	if httpErrorMessage != "" {
+	if e.httpErrorMessage != "" {
 		return true
 	}
 	return false
 }
 
 func (e *ZoneError) NotFound() bool {
-	if e.err == nil && httpErrorMessage == "" {
+	if e.err == nil && e.httpErrorMessage == "" {
 		return true
 	}
 	return false
@@ -41,10 +41,6 @@ func (e *ZoneError) ValidationFailed() bool {
 }
 
 func (e *ZoneError) Error() string {
-	if e == nil {
-		return "<nil>"
-	}
-
 	if e.Network() {
 		return fmt.Sprintf("Zone \"%s\" network error: [%s]", e.zoneName, e.httpErrorMessage)
 	}
@@ -60,6 +56,8 @@ func (e *ZoneError) Error() string {
 	if e.ValidationFailed() {
 		return fmt.Sprintf("Zone \"%s\" validation failed: [%s]", e.zoneName, e.err.Error())
 	}
+
+	return "<nil>"
 }
 
 type RecordError struct {
@@ -69,7 +67,7 @@ type RecordError struct {
 }
 
 func (e *RecordError) Network() bool {
-	if httpErrorMessage != "" {
+	if e.httpErrorMessage != "" {
 		return true
 	}
 	return false
@@ -80,24 +78,20 @@ func (e *RecordError) NotFound() bool {
 }
 
 func (e *RecordError) FailedToSave() bool {
-	if fieldName == "" {
+	if e.fieldName == "" {
 		return true
 	}
 	return false
 }
 
 func (e *RecordError) ValidationFailed() bool {
-	if fieldName != "" {
+	if e.fieldName != "" {
 		return true
 	}
 	return false
 }
 
 func (e *RecordError) Error() string {
-	if e == nil {
-		return "<nil>"
-	}
-
 	if e.Network() {
 		return fmt.Sprintf("Record network error: [%s]", e.httpErrorMessage)
 	}
@@ -113,4 +107,6 @@ func (e *RecordError) Error() string {
 	if e.ValidationFailed() {
 		return fmt.Sprintf("Record validation failed for field [%s]: [%s]", e.fieldName, e.err.Error())
 	}
+
+	return "<nil>"
 }

--- a/configdns-v1/errors.go
+++ b/configdns-v1/errors.go
@@ -68,7 +68,7 @@ type RecordError struct {
 	err              error
 }
 
-func (e *ZoneError) Network() bool {
+func (e *RecordError) Network() bool {
 	if httpErrorMessage != "" {
 		return true
 	}

--- a/configdns-v1/errors.go
+++ b/configdns-v1/errors.go
@@ -1,13 +1,44 @@
 package dns
 
-const (
-	ErrZoneNotFound = iota
-	ErrFailedToSave
+import (
+	"fmt"
 )
 
-var (
-	errorMap = map[int]string{
-		ErrZoneNotFound: "Zone \"%s\" not found, creating new zone.",
-		ErrFailedToSave: "Unable to save record (%s)",
+type Error interface {
+	error
+	IsZoneNotFound() bool
+	IsFailedToSave() bool
+}
+
+type ZoneNotFoundError struct {
+	zoneName string
+	err      error
+}
+
+type FailedToSaveError struct {
+	err error
+}
+
+func IsZoneNotFound(err error) bool {
+	_, ok := err.(*ZoneNotFoundError)
+	return ok
+}
+
+func IsFailedToSave(err error) bool {
+	_, ok := err.(*FailedToSaveError)
+	return ok
+}
+
+func (e *ZoneNotFoundError) Error() string {
+	if e == nil {
+		return "<nil>"
 	}
-)
+	return fmt.Sprintf("Zone \"%s\" not found, creating new zone.", e.zoneName)
+}
+
+func (e *FailedToSaveError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("Unable to save record (%s)", e.err.Error())
+}

--- a/configdns-v1/errors.go
+++ b/configdns-v1/errors.go
@@ -4,41 +4,113 @@ import (
 	"fmt"
 )
 
-type Error interface {
+type configDNSError interface {
 	error
-	IsZoneNotFound() bool
-	IsFailedToSave() bool
+	Network() bool
+	NotFound() bool
+	FailedToSave() bool
+	ValidationFailed() bool
 }
 
-type ZoneNotFoundError struct {
-	zoneName string
-	err      error
+type ZoneError struct {
+	zoneName         string
+	httpErrorMessage string
+	err              error
 }
 
-type FailedToSaveError struct {
-	err error
+func (e *ZoneError) Network() bool {
+	if httpErrorMessage != "" {
+		return true
+	}
+	return false
 }
 
-func IsZoneNotFound(err error) bool {
-	_, ok := err.(*ZoneNotFoundError)
-	return ok
+func (e *ZoneError) NotFound() bool {
+	if e.err == nil && httpErrorMessage == "" {
+		return true
+	}
+	return false
 }
 
-func IsFailedToSave(err error) bool {
-	_, ok := err.(*FailedToSaveError)
-	return ok
+func (e *ZoneError) FailedToSave() bool {
+	return false
 }
 
-func (e *ZoneNotFoundError) Error() string {
+func (e *ZoneError) ValidationFailed() bool {
+	return false
+}
+
+func (e *ZoneError) Error() string {
 	if e == nil {
 		return "<nil>"
 	}
-	return fmt.Sprintf("Zone \"%s\" not found, creating new zone.", e.zoneName)
+
+	if e.Network() {
+		return fmt.Sprintf("Zone \"%s\" network error: [%s]", e.zoneName, e.httpErrorMessage)
+	}
+
+	if e.NotFound() {
+		return fmt.Sprintf("Zone \"%s\" not found.", e.zoneName)
+	}
+
+	if e.FailedToSave() {
+		return fmt.Sprintf("Zone \"%s\" failed to save: [%s]", e.zoneName, e.err.Error())
+	}
+
+	if e.ValidationFailed() {
+		return fmt.Sprintf("Zone \"%s\" validation failed: [%s]", e.zoneName, e.err.Error())
+	}
 }
 
-func (e *FailedToSaveError) Error() string {
+type RecordError struct {
+	fieldName        string
+	httpErrorMessage string
+	err              error
+}
+
+func (e *ZoneError) Network() bool {
+	if httpErrorMessage != "" {
+		return true
+	}
+	return false
+}
+
+func (e *RecordError) NotFound() bool {
+	return false
+}
+
+func (e *RecordError) FailedToSave() bool {
+	if fieldName == "" {
+		return true
+	}
+	return false
+}
+
+func (e *RecordError) ValidationFailed() bool {
+	if fieldName != "" {
+		return true
+	}
+	return false
+}
+
+func (e *RecordError) Error() string {
 	if e == nil {
 		return "<nil>"
 	}
-	return fmt.Sprintf("Unable to save record (%s)", e.err.Error())
+
+	if e.Network() {
+		return fmt.Sprintf("Record network error: [%s]", e.httpErrorMessage)
+	}
+
+	if e.NotFound() {
+		return fmt.Sprintf("Record not found.")
+	}
+
+	if e.FailedToSave() {
+		return fmt.Sprintf("Record failed to save: [%s]", e.err.Error())
+	}
+
+	if e.ValidationFailed() {
+		return fmt.Sprintf("Record validation failed for field [%s]: [%s]", e.fieldName, e.err.Error())
+	}
 }

--- a/configdns-v1/init.go
+++ b/configdns-v1/init.go
@@ -1,9 +1,15 @@
 // Package configdns provides a simple wrapper around the Akamai FastDNS DNS Management API
 package dns
 
-import "github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
+import (
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
+	log "github.com/sirupsen/logrus"
+)
 
 // Init sets the FastDNS edgegrid Config
 func Init(config edgegrid.Config) {
 	Config = config
+	if Config.Debug {
+		log.SetLevel(log.DebugLevel)
+	}
 }

--- a/configdns-v1/service.go
+++ b/configdns-v1/service.go
@@ -1,10 +1,9 @@
 package dns
 
 import (
-	"fmt"
-
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -25,10 +24,12 @@ func GetZone(hostname string) (*Zone, error) {
 		return nil, err
 	}
 
+	log.Debugf("Request being sent: %s", req)
 	res, err := client.Do(Config, req)
 	if err != nil {
 		return nil, err
 	}
+	log.Debugf("Response received: %s", res)
 
 	if client.IsError(res) && res.StatusCode != 404 {
 		return nil, client.NewAPIError(res)

--- a/configdns-v1/service.go
+++ b/configdns-v1/service.go
@@ -34,7 +34,7 @@ func GetZone(hostname string) (*Zone, error) {
 	if client.IsError(res) && res.StatusCode != 404 {
 		return nil, client.NewAPIError(res)
 	} else if res.StatusCode == 404 {
-		return nil, fmt.Errorf(errorMap[ErrZoneNotFound], hostname)
+		return nil, &ZoneNotFoundError{zoneName: hostname}
 	} else {
 		err = client.BodyJSON(res, &zone)
 		if err != nil {

--- a/configdns-v1/service.go
+++ b/configdns-v1/service.go
@@ -34,7 +34,7 @@ func GetZone(hostname string) (*Zone, error) {
 	if client.IsError(res) && res.StatusCode != 404 {
 		return nil, client.NewAPIError(res)
 	} else if res.StatusCode == 404 {
-		return nil, &ZoneNotFoundError{zoneName: hostname}
+		return nil, &ZoneError{zoneName: hostname}
 	} else {
 		err = client.BodyJSON(res, &zone)
 		if err != nil {

--- a/configdns-v1/service_test.go
+++ b/configdns-v1/service_test.go
@@ -15,6 +15,7 @@ var (
 		ClientToken:  "akab-client-token-xxx-xxxxxxxxxxxxxxxx",
 		ClientSecret: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=",
 		MaxBody:      2048,
+		Debug:        true,
 	}
 )
 

--- a/configdns-v1/zone.go
+++ b/configdns-v1/zone.go
@@ -110,7 +110,7 @@ func (zone *Zone) Save() error {
 	}
 
 	if err != nil {
-		return fmt.Errorf(errorMap[ErrFailedToSave], err.Error())
+		return &FailedToSaveError{err: err}
 	}
 
 	log.Printf("[INFO] Zone Saved")

--- a/configdns-v1/zone.go
+++ b/configdns-v1/zone.go
@@ -85,13 +85,20 @@ func (zone *Zone) Save() error {
 	}
 
 	res, err := client.Do(Config, req)
+
+	// Network error
 	if err != nil {
-		return err
+		return &ZoneError{
+			zoneName:         zone.Zone.Name,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
 	}
 
+	// API error
 	if client.IsError(res) {
 		err := client.NewAPIError(res)
-		return fmt.Errorf("Unable to save record (%s)", err.Error())
+		return &ZoneError{zoneName: zone.Zone.Name, err: err}
 	}
 
 	for {
@@ -107,10 +114,6 @@ func (zone *Zone) Save() error {
 		}
 		log.Println("[DEBUG] Token not updated, retrying...")
 		time.Sleep(time.Second)
-	}
-
-	if err != nil {
-		return &FailedToSaveError{err: err}
 	}
 
 	log.Printf("[INFO] Zone Saved")


### PR DESCRIPTION
This formalises the errors used in the config-dns package. The new interface allows users implementing the library to easily identify what the error is based on the type. The design is based on the errors interface design in the [net package](https://golang.org/src/net/net.go?s=12496:12617#L364) in the standard library. This work facilitates fixing the config-dns portion of the Akamai Terraform provider. 