### PR TITLE
Fix SOA Serial Increment

### DIFF
--- a/configdns-v1/zone.go
+++ b/configdns-v1/zone.go
@@ -765,7 +765,11 @@ func (zone *Zone) removeTxtRecord(record *TxtRecord) error {
 }
 
 func (zone *Zone) PreMarshalJSON() error {
-	zone.Zone.Soa.Serial = int(time.Now().Unix())
+	if zone.Zone.Soa.Serial > 0 {
+		zone.Zone.Soa.Serial = zone.Zone.Soa.Serial + 1
+	} else {
+		zone.Zone.Soa.Serial = int(time.Now().Unix())
+	}
 	return nil
 }
 


### PR DESCRIPTION
This fixes the SOA serial number so it is always unique. Previously when relying only on the timestamp, if multiple save commands occur in the same second, the requests would fail because the serial number was not unique and incremented across requests. 