### PR TITLE
WIP: Implements client-v2 with refactored methods

### DIFF
--- a/client-v2/README.md
+++ b/client-v2/README.md
@@ -1,0 +1,29 @@
+# Akamai Client
+
+A golang package which helps facilitate making HTTP requests to [Akamai OPEN APIs](https://developer.akamai.com)
+
+## Example of use
+```
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	client "github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v2"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
+)
+
+func main() {
+	//TODO: This one does not handle missing sections :(
+	config, _ := edgegrid.Init("~/.edgerc", "ingbv")
+
+	client.Init(config)
+	resp, _ := client.RequestHTTP("GET", "/diagnostic-tools/v1/locations", nil)
+
+	defer resp.Body.Close()
+	byt, _ := ioutil.ReadAll(resp.Body)
+	fmt.Println(string(byt))
+}
+
+```

--- a/client-v2/api.go
+++ b/client-v2/api.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"encoding/json"
+)
+
+// Resource is the "base" type for all API resources
+type Resource struct {
+	Complete chan bool `json:"-"`
+}
+
+// Init initializes the Complete channel, if it is necessary
+// need to create a resource specific Init(), make sure to
+// initialize the channel.
+func (resource *Resource) Init() {
+	resource.Complete = make(chan bool, 1)
+}
+
+// PostUnmarshalJSON is a default implementation of the
+// PostUnmarshalJSON hook that simply calls Init() and
+// sends true to the Complete channel. This is overridden
+// in many resources, in particular those that represent
+// collections, and have to initialize sub-resources also.
+func (resource *Resource) PostUnmarshalJSON() error {
+	resource.Init()
+	resource.Complete <- true
+	return nil
+}
+
+// GetJSON returns the raw (indented) JSON (as []bytes)
+func (resource *Resource) GetJSON() ([]byte, error) {
+	return json.MarshalIndent(resource, "", "    ")
+}
+
+// JSONBody is a generic struct for temporary JSON unmarshalling.
+type JSONBody map[string]interface{}

--- a/client-v2/api.go
+++ b/client-v2/api.go
@@ -1,4 +1,4 @@
-package client
+package edgeClient
 
 import (
 	"encoding/json"

--- a/client-v2/api_test.go
+++ b/client-v2/api_test.go
@@ -1,0 +1,38 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/jsonhooks-v1"
+	"github.com/stretchr/testify/assert"
+)
+
+type Test struct {
+	Resource
+	Foo string `json:"foo"`
+}
+
+func (test *Test) PreMarshalJSON() error {
+	test.Foo = "bat"
+
+	return nil
+}
+
+func TestResourceUnmarshal(t *testing.T) {
+	body := []byte(`{"foo":"bar"}`)
+
+	test := &Test{}
+	err := jsonhooks.Unmarshal(body, test)
+
+	assert.NoError(t, err)
+	assert.True(t, <-test.Complete)
+}
+
+func TestResourceMarshal(t *testing.T) {
+	test := &Test{Foo: "bar"}
+
+	body, err := jsonhooks.Marshal(test)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(`{"foo":"bat"}`), body)
+}

--- a/client-v2/api_test.go
+++ b/client-v2/api_test.go
@@ -1,4 +1,4 @@
-package client
+package edgeClient
 
 import (
 	"testing"

--- a/client-v2/client.go
+++ b/client-v2/client.go
@@ -1,0 +1,155 @@
+// Package client is a simple library for http.Client to sign Akamai OPEN Edgegrid API requests
+package client
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"runtime"
+	"strings"
+
+	edgegrid "github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/jsonhooks-v1"
+)
+
+const (
+	libraryVersion = "0.5.0"
+)
+
+var (
+	edgercConfig  edgegrid.Config
+	isInitialized bool
+	UserAgent     = "Akamai-Open-Edgegrid-golang/" + libraryVersion + " golang/" + strings.TrimPrefix(runtime.Version(), "go")
+	Client        = http.DefaultClient
+)
+
+//Init initialise our client with selected configuration which later on can be used
+func Init(c edgegrid.Config) {
+	edgercConfig = c
+	fmt.Println("Print me host :")
+	fmt.Println(c.Host)
+	isInitialized = true
+}
+
+// prepareHTTPRequest creates an HTTP request accordingly to requirements of Akamai API
+func prepareHTTPRequest(method, path string, body io.Reader) (*http.Request, error) {
+	var (
+		baseURL *url.URL
+		err     error
+	)
+
+	if isInitialized != true {
+		return nil, err
+	}
+
+	if strings.HasPrefix(edgercConfig.Host, "https://") {
+		baseURL, err = url.Parse(edgercConfig.Host)
+	} else {
+		baseURL, err = url.Parse("https://" + edgercConfig.Host)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	rel, err := url.Parse(strings.TrimPrefix(path, "/"))
+	if err != nil {
+		return nil, err
+	}
+
+	u := baseURL.ResolveReference(rel)
+
+	req, err := http.NewRequest(method, u.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("User-Agent", UserAgent)
+
+	return req, nil
+}
+
+// RequestHTTP creates an HTTP request accordingly to requirements of Akamais API
+// and execute it returning response object.
+func RequestHTTP(method, path string, body io.Reader) (*http.Response, error) {
+	var (
+		err error
+	)
+
+	if isInitialized != true {
+		return nil, err
+	}
+
+	req, err := prepareHTTPRequest(method, path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := ExecuteRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// RequestJSON creates an HTTP request that can be sent to the Akamai APIs with a JSON body
+// The JSON body is encoded and the Content-Type/Accept headers are set automatically.
+func RequestJSON(method, path string, body interface{}) (*http.Response, error) {
+	jsonBody, err := jsonhooks.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := bytes.NewReader(jsonBody)
+	req, err := prepareHTTPRequest(method, path, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json,*/*")
+
+	res, err := ExecuteRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// ExecuteRequest performs a given HTTP Request, signed with the Akamai OPEN Edgegrid
+// Authorization header. An edgegrid.Response or an error is returned.
+func ExecuteRequest(req *http.Request) (*http.Response, error) {
+	Client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		req = edgegrid.AddRequestHeader(edgercConfig, req)
+		return nil
+	}
+
+	req = edgegrid.AddRequestHeader(edgercConfig, req)
+	res, err := Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+// BodyJSON unmarshals the Response.Body into a given data structure
+func BodyJSON(r *http.Response, data interface{}) error {
+	if data == nil {
+		return errors.New("You must pass in an interface{}")
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return err
+	}
+	err = jsonhooks.Unmarshal(body, data)
+
+	return err
+}

--- a/client-v2/client.go
+++ b/client-v2/client.go
@@ -1,5 +1,5 @@
-// Package client is a simple library for http.Client to sign Akamai OPEN Edgegrid API requests
-package client
+// Package edgeClient is library for making Akamai OPEN Edgegrid API requests
+package edgeClient
 
 import (
 	"bytes"
@@ -33,6 +33,12 @@ type Client struct {
 
 	// User agent used when communicating with the GitLab API.
 	UserAgent string
+}
+
+// NewClient returns a new edgeClient API client. If a nil httpClient is
+// provided, http.DefaultClient will be used.
+func NewClient(c edgegrid.Config, httpClient *http.Client) *Client {
+	return newClient(c, httpClient)
 }
 
 func newClient(c edgegrid.Config, httpClient *http.Client) *Client {

--- a/client-v2/errors.go
+++ b/client-v2/errors.go
@@ -1,0 +1,88 @@
+package client
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/jsonhooks-v1"
+)
+
+// APIError exposes an Akamai OPEN Edgegrid Error
+type APIError struct {
+	error
+	Type        string         `json:"type"`
+	Title       string         `json:"title"`
+	Status      int            `json:"status"`
+	Detail      string         `json:"detail"`
+	Instance    string         `json:"instance"`
+	Method      string         `json:"method"`
+	ServerIP    string         `json:"serverIp"`
+	ClientIP    string         `json:"clientIp"`
+	RequestID   string         `json:"requestId"`
+	RequestTime string         `json:"requestTime"`
+	Response    *http.Response `json:"-"`
+	RawBody     string         `json:"-"`
+}
+
+func (error APIError) Error() string {
+	return strings.TrimSpace(fmt.Sprintf("API Error: %d %s %s More Info %s", error.Status, error.Title, error.Detail, error.Type))
+}
+
+// NewAPIError creates a new API error based on a Response,
+// or http.Response-like.
+func NewAPIError(response *http.Response) APIError {
+	// TODO: handle this error
+	body, _ := ioutil.ReadAll(response.Body)
+
+	return NewAPIErrorFromBody(response, body)
+}
+
+// NewAPIErrorFromBody creates a new API error, allowing you to pass in a body
+//
+// This function is intended to be used after the body has already been read for
+// other purposes.
+func NewAPIErrorFromBody(response *http.Response, body []byte) APIError {
+	error := APIError{}
+
+	if err := jsonhooks.Unmarshal(body, &error); err == nil {
+		error.Status = response.StatusCode
+		error.Title = response.Status
+	}
+
+	error.Response = response
+	error.RawBody = string(body)
+
+	return error
+}
+
+// IsInformational determines if a response was informational (1XX status)
+func IsInformational(r *http.Response) bool {
+	return r.StatusCode > 99 && r.StatusCode < 200
+}
+
+// IsSuccess determines if a response was successful (2XX status)
+func IsSuccess(r *http.Response) bool {
+	return r.StatusCode > 199 && r.StatusCode < 300
+}
+
+// IsRedirection determines if a response was a redirect (3XX status)
+func IsRedirection(r *http.Response) bool {
+	return r.StatusCode > 299 && r.StatusCode < 400
+}
+
+// IsClientError determines if a response was a client error (4XX status)
+func IsClientError(r *http.Response) bool {
+	return r.StatusCode > 399 && r.StatusCode < 500
+}
+
+// IsServerError determines if a response was a server error (5XX status)
+func IsServerError(r *http.Response) bool {
+	return r.StatusCode > 499 && r.StatusCode < 600
+}
+
+// IsError determines if the response was a client or server error (4XX or 5XX status)
+func IsError(r *http.Response) bool {
+	return r.StatusCode > 399 && r.StatusCode < 600
+}

--- a/client-v2/errors.go
+++ b/client-v2/errors.go
@@ -1,4 +1,4 @@
-package client
+package edgeClient
 
 import (
 	"fmt"


### PR DESCRIPTION
# Implements client-v2 
This pull request changes the way that client is making the requests making sure that separation of concern is kept but also changing the methods responsibility and the flow of calls itself. 

# Reasoning: 
Approach to initialise client with specific config and then allowing calls to be executed with single methods is currently best practice approach. Allowing for clean and easy to understand code. 

# Changes 
Libraries using client will have to change the code to adapt to initialisation and new simplified methods for making requests. This change does not keep `backward compatibility`. 

## Before
```golang
    config, _ := edgegrid.Init("~/.edgerc", "default")

    // Retrieve all locations for diagnostic tools
    req, _ := client.NewRequest(config, "GET", "/diagnostic-tools/v1/locations", nil)
    resp, _ := client.Do(config, req)
```

## Now
```golang
package main

import (
	"fmt"
	"io/ioutil"

	"github.com/RafPe/AkamaiOPEN-edgegrid-golang/client-v2"
	"github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
)

func main() {
	//TODO: This one does not handle missing sections :(
	config, _ := edgegrid.Init("~/.edgerc", "section-name")

	apiClient := edgeClient.NewClient(config, nil)
	resp, _ := apiClient.RequestHTTP("GET", "/diagnostic-tools/v1/locations", nil)

	defer resp.Body.Close()
	byt, _ := ioutil.ReadAll(resp.Body)
	fmt.Println(string(byt))
}
```
And for `json` 

```golang
	resp, _ := client.RequestJSON("GET", "/diagnostic-tools/v1/locations", nil)
```

# Future use case scenarios
This change will have impact on associated `akamai-cli` libraries as well as future `terraform provider` by making it simplified and easier to expand. 
