### PR TITLE
Support for api-endpoints-v2 for API Gateway, Security, and Keys CLI

### DIFF
--- a/api-endpoints-v2/activations.go
+++ b/api-endpoints-v2/activations.go
@@ -12,44 +12,14 @@ type Activation struct {
 	Notes                  string   `json:"notes"`
 }
 
-type ActivateEndpointOptions struct {
-	APIEndPointId int
-	VersionNumber int
-}
-
-func ActivateEndpoint(options *ActivateEndpointOptions, activation *Activation) (*Activation, error) {
+func ActivateEndpoint(endpointId int, version int, activation *Activation) (*Activation, error) {
 	req, err := client.NewJSONRequest(
 		Config,
 		"POST",
 		fmt.Sprintf(
 			"/api-definitions/v2/endpoints/%d/versions/%d/activate",
-			options.APIEndPointId,
-			options.VersionNumber,
-		),
-		activation,
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := client.Do(Config, req)
-
-	if client.IsError(res) {
-		return nil, client.NewAPIError(res)
-	}
-
-	return activation, nil
-}
-
-func DeactivateEndpoint(options *ActivateEndpointOptions, activation *Activation) (*Activation, error) {
-	req, err := client.NewJSONRequest(
-		Config,
-		"DELETE",
-		fmt.Sprintf(
-			"/api-definitions/v2/endpoints/%d/versions/%d/deactivate",
-			options.APIEndPointId,
-			options.VersionNumber,
+			endpointId,
+			version,
 		),
 		activation,
 	)

--- a/api-endpoints-v2/activations.go
+++ b/api-endpoints-v2/activations.go
@@ -39,13 +39,13 @@ func ActivateEndpoint(endpointId int, version int, activation *Activation) (*Act
 
 func IsActive(endpoint *Endpoint, network string) bool {
 	if network == "production" {
-		if endpoint.ProductionStatus == StatusPending || endpoint.ProductionStatus == StatusActive {
+		if endpoint.ProductionStatus == "PENDING" || endpoint.ProductionStatus == "ACTIVE" {
 			return true
 		}
 	}
 
 	if network == "staging" {
-		if endpoint.StagingStatus == StatusPending || endpoint.StagingStatus == StatusActive {
+		if endpoint.StagingStatus == "PENDING" || endpoint.StagingStatus == "ACTIVE" {
 			return true
 		}
 	}

--- a/api-endpoints-v2/api_privacy_settings.go
+++ b/api-endpoints-v2/api_privacy_settings.go
@@ -18,17 +18,6 @@ type APIPrivacyResource struct {
 }
 
 func GetAPIPrivacySettings(endpointId, version int) (*APIPrivacySettings, error) {
-	if version == 0 {
-		versions, err := ListVersions(endpointId)
-		if err != nil {
-			return nil, err
-		}
-
-		loc := len(versions.APIVersions) - 1
-		v := versions.APIVersions[loc]
-		version = v.VersionNumber
-	}
-
 	req, err := client.NewJSONRequest(
 		Config,
 		"GET",
@@ -63,17 +52,6 @@ func GetAPIPrivacySettings(endpointId, version int) (*APIPrivacySettings, error)
 }
 
 func UpdateAPIPrivacySettings(endpointId, version int, settings *APIPrivacySettings) (*APIPrivacySettings, error) {
-	if version == 0 {
-		versions, err := ListVersions(endpointId)
-		if err != nil {
-			return nil, err
-		}
-
-		loc := len(versions.APIVersions) - 1
-		v := versions.APIVersions[loc]
-		version = v.VersionNumber
-	}
-
 	req, err := client.NewJSONRequest(
 		Config,
 		"PUT",

--- a/api-endpoints-v2/api_privacy_settings.go
+++ b/api-endpoints-v2/api_privacy_settings.go
@@ -19,7 +19,7 @@ type APIPrivacyResource struct {
 
 func GetAPIPrivacySettings(endpointId, version int) (*APIPrivacySettings, error) {
 	if version == 0 {
-		versions, err := ListVersions(&ListVersionsOptions{EndpointId: endpointId})
+		versions, err := ListVersions(endpointId)
 		if err != nil {
 			return nil, err
 		}
@@ -64,7 +64,7 @@ func GetAPIPrivacySettings(endpointId, version int) (*APIPrivacySettings, error)
 
 func UpdateAPIPrivacySettings(endpointId, version int, settings *APIPrivacySettings) (*APIPrivacySettings, error) {
 	if version == 0 {
-		versions, err := ListVersions(&ListVersionsOptions{EndpointId: endpointId})
+		versions, err := ListVersions(endpointId)
 		if err != nil {
 			return nil, err
 		}

--- a/api-endpoints-v2/api_privacy_settings.go
+++ b/api-endpoints-v2/api_privacy_settings.go
@@ -2,8 +2,12 @@ package apiendpoints
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cast"
 )
 
 type APIPrivacySettings struct {
@@ -78,4 +82,34 @@ func UpdateAPIPrivacySettings(endpointId, version int, settings *APIPrivacySetti
 	}
 
 	return settings, nil
+}
+
+func (settings *APIPrivacySettings) ToTable() *tablewriter.Table {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{
+		"Endpoint Private",
+		"Resource Path",
+		"Resource Methods",
+		"Inherits from Endpoint",
+		"Resource Private",
+	})
+
+	table.Append([]string{
+		cast.ToString(settings.Public),
+		"",
+		"",
+		"",
+		"",
+	})
+
+	for _, resource := range settings.Resources {
+		table.Append([]string{
+			"",
+			cast.ToString(resource.Path),
+			cast.ToString(strings.Join(resource.Methods[:], ",")),
+			cast.ToString(resource.InheritsFromEndpoint),
+			cast.ToString(resource.Public),
+		})
+	}
+	return table
 }

--- a/api-endpoints-v2/api_privacy_settings.go
+++ b/api-endpoints-v2/api_privacy_settings.go
@@ -87,11 +87,11 @@ func UpdateAPIPrivacySettings(endpointId, version int, settings *APIPrivacySetti
 func (settings *APIPrivacySettings) ToTable() *tablewriter.Table {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{
-		"Endpoint Private",
+		"Endpoint",
 		"Resource Path",
-		"Resource Methods",
+		"Methods",
 		"Inherits from Endpoint",
-		"Resource Private",
+		"Visibility",
 	})
 
 	table.Append([]string{
@@ -103,12 +103,22 @@ func (settings *APIPrivacySettings) ToTable() *tablewriter.Table {
 	})
 
 	for _, resource := range settings.Resources {
+		i := "no"
+		if resource.InheritsFromEndpoint == true {
+			i = "yes"
+		}
+
+		v := "private"
+		if resource.Public == true {
+			v = "public"
+		}
+
 		table.Append([]string{
 			"",
 			cast.ToString(resource.Path),
 			cast.ToString(strings.Join(resource.Methods[:], ",")),
-			cast.ToString(resource.InheritsFromEndpoint),
-			cast.ToString(resource.Public),
+			i,
+			v,
 		})
 	}
 	return table

--- a/api-endpoints-v2/api_privacy_settings.go
+++ b/api-endpoints-v2/api_privacy_settings.go
@@ -18,6 +18,17 @@ type APIPrivacyResource struct {
 }
 
 func GetAPIPrivacySettings(endpointId, version int) (*APIPrivacySettings, error) {
+	if version == 0 {
+		versions, err := ListVersions(&ListVersionsOptions{EndpointId: endpointId})
+		if err != nil {
+			return nil, err
+		}
+
+		loc := len(versions.APIVersions) - 1
+		v := versions.APIVersions[loc]
+		version = v.VersionNumber
+	}
+
 	req, err := client.NewJSONRequest(
 		Config,
 		"GET",
@@ -52,6 +63,17 @@ func GetAPIPrivacySettings(endpointId, version int) (*APIPrivacySettings, error)
 }
 
 func UpdateAPIPrivacySettings(endpointId, version int, settings *APIPrivacySettings) (*APIPrivacySettings, error) {
+	if version == 0 {
+		versions, err := ListVersions(&ListVersionsOptions{EndpointId: endpointId})
+		if err != nil {
+			return nil, err
+		}
+
+		loc := len(versions.APIVersions) - 1
+		v := versions.APIVersions[loc]
+		version = v.VersionNumber
+	}
+
 	req, err := client.NewJSONRequest(
 		Config,
 		"PUT",

--- a/api-endpoints-v2/api_privacy_settings.go
+++ b/api-endpoints-v2/api_privacy_settings.go
@@ -94,8 +94,12 @@ func (settings *APIPrivacySettings) ToTable() *tablewriter.Table {
 		"Visibility",
 	})
 
+	es := "private"
+	if settings.Public == true {
+		es = "public"
+	}
 	table.Append([]string{
-		cast.ToString(settings.Public),
+		es,
 		"",
 		"",
 		"",

--- a/api-endpoints-v2/api_privacy_settings.go
+++ b/api-endpoints-v2/api_privacy_settings.go
@@ -1,5 +1,11 @@
 package apiendpoints
 
+import (
+	"fmt"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
+)
+
 type APIPrivacySettings struct {
 	Resources map[int]APIPrivacyResource `json:"resources"`
 	Public    bool                       `json:"public"`
@@ -9,4 +15,67 @@ type APIPrivacyResource struct {
 	ResourceSettings
 	Notes  string `json:"notes"`
 	Public bool   `json:"public"`
+}
+
+func GetAPIPrivacySettings(endpointId, version int) (*APIPrivacySettings, error) {
+	req, err := client.NewJSONRequest(
+		Config,
+		"GET",
+		fmt.Sprintf(
+			"/api-definitions/v2/endpoints/%d/versions/%d/settings/api-privacy",
+			endpointId,
+			version,
+		),
+		nil,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := client.Do(Config, req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if client.IsError(res) {
+		return nil, client.NewAPIError(res)
+	}
+
+	rep := &APIPrivacySettings{}
+	if err = client.BodyJSON(res, rep); err != nil {
+		return nil, err
+	}
+
+	return rep, nil
+}
+
+func UpdateAPIPrivacySettings(endpointId, version int, settings *APIPrivacySettings) (*APIPrivacySettings, error) {
+	req, err := client.NewJSONRequest(
+		Config,
+		"PUT",
+		fmt.Sprintf(
+			"/api-definitions/v2/endpoints/%d/versions/%d/settings/api-privacy",
+			endpointId,
+			version,
+		),
+		settings,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := client.Do(Config, req)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if client.IsError(res) {
+		return nil, client.NewAPIError(res)
+	}
+
+	return settings, nil
 }

--- a/api-endpoints-v2/endpoints.go
+++ b/api-endpoints-v2/endpoints.go
@@ -29,6 +29,7 @@ type Endpoint struct {
 	CreatedBy                  string                `json:"createdBy,omitempty"`
 	Description                string                `json:"description,omitempty"`
 	GroupID                    int                   `json:"groupId,omitempty"`
+	LockVersion                int                   `json:"lockVersion"`
 	ProductionVersion          *VersionSummary       `json:"productionVersion,omitempty"`
 	ProductionStatus           string                `json:"productionStatus,omitempty"`
 	ProtectedByAPIKey          bool                  `json:"protectedByApiKey,omitempty"`

--- a/api-endpoints-v2/endpoints.go
+++ b/api-endpoints-v2/endpoints.go
@@ -2,6 +2,7 @@ package apiendpoints
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
 	"github.com/google/go-querystring/query"
@@ -58,7 +59,7 @@ type SecurityRestrictions struct {
 
 type CreateEndpointOptions struct {
 	ContractId string   `json:"contractId,omitempty"`
-	GroupId    string   `json:"groupId,omitempty"`
+	GroupId    int      `json:"groupId,omitempty"`
 	Name       string   `json:"apiEndPointName,omitempty"`
 	BasePath   string   `json:"basePath,omitempty"`
 	Hostnames  []string `json:"apiEndPointHosts,omitempty"`
@@ -79,7 +80,7 @@ type CreateEndpointFromFileOptions struct {
 	File       string
 	Format     string
 	ContractId string
-	GroupId    string
+	GroupId    int
 }
 
 func CreateEndpointFromFile(options *CreateEndpointFromFileOptions) (*Endpoint, error) {
@@ -89,7 +90,7 @@ func CreateEndpointFromFile(options *CreateEndpointFromFileOptions) (*Endpoint, 
 		options.File,
 		map[string]string{
 			"contractId":       options.ContractId,
-			"groupId":          options.GroupId,
+			"groupId":          strconv.Itoa(options.GroupId),
 			"importFileFormat": options.Format,
 		},
 	)

--- a/api-endpoints-v2/endpoints.go
+++ b/api-endpoints-v2/endpoints.go
@@ -103,16 +103,20 @@ func (es *EndpointSecurity) ToTable() *tablewriter.Table {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.Append([]string{"ID", cast.ToString(es.APIEndPointID)})
 	table.Append([]string{"Name", cast.ToString(es.APIEndPointName)})
-	table.Append([]string{"Security Scheme Type", cast.ToString(es.SecurityScheme.SecuritySchemeType)})
-	table.Append([]string{"API Key Name", cast.ToString(es.SecurityScheme.SecuritySchemeDetail.APIKeyName)})
-	table.Append([]string{"API Key Location", cast.ToString(es.SecurityScheme.SecuritySchemeDetail.APIKeyLocation)})
-	table.Append([]string{"Max JSON XML Element", cast.ToString(es.AkamaiSecurityRestrictions.MaxJsonxmlElement)})
-	table.Append([]string{"Max Element Name Length", cast.ToString(es.AkamaiSecurityRestrictions.MaxElementNameLength)})
-	table.Append([]string{"Max Doc Depth", cast.ToString(es.AkamaiSecurityRestrictions.MaxDocDepth)})
-	table.Append([]string{"Positive Security Enabled", cast.ToString(es.AkamaiSecurityRestrictions.PositiveSecurityEnabled)})
-	table.Append([]string{"Max String Length", cast.ToString(es.AkamaiSecurityRestrictions.MaxStringLength)})
-	table.Append([]string{"Max Body Size", cast.ToString(es.AkamaiSecurityRestrictions.MaxBodySize)})
-	table.Append([]string{"Max Integer Value", cast.ToString(es.AkamaiSecurityRestrictions.MaxIntegerValue)})
+	if es.SecurityScheme != nil {
+		table.Append([]string{"Security Scheme Type", cast.ToString(es.SecurityScheme.SecuritySchemeType)})
+		table.Append([]string{"API Key Name", cast.ToString(es.SecurityScheme.SecuritySchemeDetail.APIKeyName)})
+		table.Append([]string{"API Key Location", cast.ToString(es.SecurityScheme.SecuritySchemeDetail.APIKeyLocation)})
+	}
+	if es.AkamaiSecurityRestrictions != nil {
+		table.Append([]string{"Max JSON XML Element", cast.ToString(es.AkamaiSecurityRestrictions.MaxJsonxmlElement)})
+		table.Append([]string{"Max Element Name Length", cast.ToString(es.AkamaiSecurityRestrictions.MaxElementNameLength)})
+		table.Append([]string{"Max Doc Depth", cast.ToString(es.AkamaiSecurityRestrictions.MaxDocDepth)})
+		table.Append([]string{"Positive Security Enabled", cast.ToString(es.AkamaiSecurityRestrictions.PositiveSecurityEnabled)})
+		table.Append([]string{"Max String Length", cast.ToString(es.AkamaiSecurityRestrictions.MaxStringLength)})
+		table.Append([]string{"Max Body Size", cast.ToString(es.AkamaiSecurityRestrictions.MaxBodySize)})
+		table.Append([]string{"Max Integer Value", cast.ToString(es.AkamaiSecurityRestrictions.MaxIntegerValue)})
+	}
 	return table
 }
 

--- a/api-endpoints-v2/endpoints.go
+++ b/api-endpoints-v2/endpoints.go
@@ -130,6 +130,35 @@ func UpdateEndpointFromFile(options *UpdateEndpointFromFileOptions) (*Endpoint, 
 	return call(req, err)
 }
 
+func (endpoint *Endpoint) ToTable() *tablewriter.Table {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{
+		"ID",
+		"Name",
+		"Version",
+		"Base Path",
+		"# Resources",
+		"Private",
+		"Staging Status",
+		"Production Status",
+	})
+	l := 0
+	if endpoint.APIResourceBaseInfo != nil {
+		l = len(endpoint.APIResourceBaseInfo)
+	}
+	table.Append([]string{
+		cast.ToString(endpoint.APIEndPointID),
+		cast.ToString(endpoint.APIEndPointName),
+		cast.ToString(endpoint.VersionNumber),
+		cast.ToString(endpoint.BasePath),
+		cast.ToString(l),
+		cast.ToString(endpoint.ProtectedByAPIKey),
+		cast.ToString(endpoint.StagingStatus),
+		cast.ToString(endpoint.ProductionStatus),
+	})
+	return table
+}
+
 type ListEndpointOptions struct {
 	ContractId        string `url:"contractId,omitempty"`
 	GroupId           int    `url:"groupId,omitempty"`

--- a/api-endpoints-v2/endpoints.go
+++ b/api-endpoints-v2/endpoints.go
@@ -30,11 +30,11 @@ type Endpoint struct {
 	Description                string                `json:"description,omitempty"`
 	GroupID                    int                   `json:"groupId,omitempty"`
 	LockVersion                int                   `json:"lockVersion"`
-	ProductionVersion          *VersionSummary       `json:"productionVersion,omitempty"`
+	ProductionVersion          *VersionSummary       `json:"productionVersion"`
 	ProductionStatus           string                `json:"productionStatus,omitempty"`
 	ProtectedByAPIKey          bool                  `json:"protectedByApiKey,omitempty"`
 	StagingStatus              string                `json:"stagingStatus,omitempty"`
-	StagingVersion             *VersionSummary       `json:"stagingVersion,omitempty"`
+	StagingVersion             *VersionSummary       `json:"stagingVersion"`
 	UpdateDate                 string                `json:"updateDate,omitempty"`
 	UpdatedBy                  string                `json:"updatedBy,omitempty"`
 	VersionNumber              int                   `json:"versionNumber,omitempty"`
@@ -61,6 +61,35 @@ type SecurityRestrictions struct {
 	MaxStringLength         int `json:"MAX_STRING_LENGTH,omitempty"`
 	MaxBodySize             int `json:"MAX_BODY_SIZE,omitempty"`
 	MaxIntegerValue         int `json:"MAX_INTEGER_VALUE,omitempty"`
+}
+
+type EndpointStatus struct {
+	APIEndPointID     int             `json:"apiEndPointId,omitempty"`
+	APIEndPointName   string          `json:"apiEndPointName"`
+	ProductionVersion *VersionSummary `json:"productionVersion,omitempty"`
+	StagingVersion    *VersionSummary `json:"stagingVersion,omitempty"`
+}
+
+func (es *EndpointStatus) ToTable() *tablewriter.Table {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{
+		"ID",
+		"Name",
+		"Production Version",
+		"Production Status",
+		"Staging Version",
+		"Staging Status",
+	})
+
+	table.Append([]string{
+		cast.ToString(es.APIEndPointID),
+		cast.ToString(es.APIEndPointName),
+		cast.ToString(es.ProductionVersion.VersionNumber),
+		cast.ToString(es.ProductionVersion.Status),
+		cast.ToString(es.StagingVersion.VersionNumber),
+		cast.ToString(es.StagingVersion.Status),
+	})
+	return table
 }
 
 type CreateEndpointOptions struct {

--- a/api-endpoints-v2/endpoints.go
+++ b/api-endpoints-v2/endpoints.go
@@ -188,8 +188,8 @@ func (list *EndpointList) ToTable() *tablewriter.Table {
 
 	for _, endpoint := range list.APIEndPoints {
 		l := 0
-		if endpoint.APIResources != nil {
-			l = len(*endpoint.APIResources)
+		if endpoint.APIResourceBaseInfo != nil {
+			l = len(endpoint.APIResourceBaseInfo)
 		}
 		table.Append([]string{
 			cast.ToString(endpoint.APIEndPointID),

--- a/api-endpoints-v2/endpoints.go
+++ b/api-endpoints-v2/endpoints.go
@@ -40,11 +40,13 @@ type Endpoint struct {
 }
 
 type SecurityScheme struct {
-	SecuritySchemeType   string `json:"securitySchemeType,omitempty"`
-	SecuritySchemeDetail struct {
-		APIKeyLocation string `json:"apiKeyLocation,omitempty"`
-		APIKeyName     string `json:"apiKeyName,omitempty"`
-	} `json:"securitySchemeDetail,omitempty"`
+	SecuritySchemeType   string                `json:"securitySchemeType,omitempty"`
+	SecuritySchemeDetail *SecuritySchemeDetail `json:"securitySchemeDetail,omitempty"`
+}
+
+type SecuritySchemeDetail struct {
+	APIKeyLocation string `json:"apiKeyLocation,omitempty"`
+	APIKeyName     string `json:"apiKeyName,omitempty"`
 }
 
 type SecurityRestrictions struct {

--- a/api-endpoints-v2/endpoints.go
+++ b/api-endpoints-v2/endpoints.go
@@ -92,6 +92,30 @@ func (es *EndpointStatus) ToTable() *tablewriter.Table {
 	return table
 }
 
+type EndpointSecurity struct {
+	APIEndPointID              int                   `json:"apiEndPointId,omitempty"`
+	APIEndPointName            string                `json:"apiEndPointName"`
+	SecurityScheme             *SecurityScheme       `json:"securityScheme,omitempty"`
+	AkamaiSecurityRestrictions *SecurityRestrictions `json:"akamaiSecurityRestrictions,omitempty"`
+}
+
+func (es *EndpointSecurity) ToTable() *tablewriter.Table {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.Append([]string{"ID", cast.ToString(es.APIEndPointID)})
+	table.Append([]string{"Name", cast.ToString(es.APIEndPointName)})
+	table.Append([]string{"Security Scheme Type", cast.ToString(es.SecurityScheme.SecuritySchemeType)})
+	table.Append([]string{"API Key Name", cast.ToString(es.SecurityScheme.SecuritySchemeDetail.APIKeyName)})
+	table.Append([]string{"API Key Location", cast.ToString(es.SecurityScheme.SecuritySchemeDetail.APIKeyLocation)})
+	table.Append([]string{"Max JSON XML Element", cast.ToString(es.AkamaiSecurityRestrictions.MaxJsonxmlElement)})
+	table.Append([]string{"Max Element Name Length", cast.ToString(es.AkamaiSecurityRestrictions.MaxElementNameLength)})
+	table.Append([]string{"Max Doc Depth", cast.ToString(es.AkamaiSecurityRestrictions.MaxDocDepth)})
+	table.Append([]string{"Positive Security Enabled", cast.ToString(es.AkamaiSecurityRestrictions.PositiveSecurityEnabled)})
+	table.Append([]string{"Max String Length", cast.ToString(es.AkamaiSecurityRestrictions.MaxStringLength)})
+	table.Append([]string{"Max Body Size", cast.ToString(es.AkamaiSecurityRestrictions.MaxBodySize)})
+	table.Append([]string{"Max Integer Value", cast.ToString(es.AkamaiSecurityRestrictions.MaxIntegerValue)})
+	return table
+}
+
 type CreateEndpointOptions struct {
 	ContractId string   `json:"contractId,omitempty"`
 	GroupId    int      `json:"groupId,omitempty"`

--- a/api-endpoints-v2/endpoints.go
+++ b/api-endpoints-v2/endpoints.go
@@ -2,10 +2,13 @@ package apiendpoints
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
 	"github.com/google/go-querystring/query"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cast"
 )
 
 type Endpoints []Endpoint
@@ -177,6 +180,27 @@ func (list *EndpointList) ListEndpoints(options *ListEndpointOptions) error {
 	}
 
 	return nil
+}
+
+func (list *EndpointList) ToTable() *tablewriter.Table {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"ID", "Name", "Version", "Base Path", "# Resources", "Private"})
+
+	for _, endpoint := range list.APIEndPoints {
+		l := 0
+		if endpoint.APIResources != nil {
+			l = len(*endpoint.APIResources)
+		}
+		table.Append([]string{
+			cast.ToString(endpoint.APIEndPointID),
+			cast.ToString(endpoint.APIEndPointName),
+			cast.ToString(endpoint.VersionNumber),
+			cast.ToString(endpoint.BasePath),
+			cast.ToString(l),
+			cast.ToString(endpoint.ProtectedByAPIKey),
+		})
+	}
+	return table
 }
 
 func RemoveEndpoint(endpointId int) (*Endpoint, error) {

--- a/api-endpoints-v2/methods.go
+++ b/api-endpoints-v2/methods.go
@@ -4,7 +4,7 @@ type Methods []Method
 
 type Method struct {
 	APIResourceMethodID      int          `json:"apiResourceMethodId"`
-	APIResourceMethod        MethodValue  `json:"apiResourceMethod"`
+	APIResourceMethod        string       `json:"apiResourceMethod"`
 	APIResourceMethodLogicID int          `json:"apiResourceMethodLogicId"`
 	APIParameters            []Parameters `json:"apiParameters"`
 }
@@ -12,11 +12,11 @@ type Method struct {
 type MethodValue string
 
 const (
-	MethodGet     MethodValue = "get"
-	MethodPost    MethodValue = "post"
-	MethodPut     MethodValue = "put"
-	MethodDelete  MethodValue = "delete"
-	MethodHead    MethodValue = "head"
-	MethodPatch   MethodValue = "patch"
-	MethodOptions MethodValue = "options"
+	MethodGet     string = "get"
+	MethodPost    string = "post"
+	MethodPut     string = "put"
+	MethodDelete  string = "delete"
+	MethodHead    string = "head"
+	MethodPatch   string = "patch"
+	MethodOptions string = "options"
 )

--- a/api-endpoints-v2/parameters.go
+++ b/api-endpoints-v2/parameters.go
@@ -9,6 +9,8 @@ type Parameters struct {
 	APIParameterType        APIParameterTypeValue     `json:"apiParameterType"`
 	APIParameterNotes       *string                   `json:"apiParameterNotes"`
 	APIParamLogicID         int                       `json:"apiParamLogicId"`
+	PathParamLocationId     int                       `json:"pathParamLocationId"`
+	APIResourceMethParamId  int                       `json:"apiResourceMethParamId"`
 	Array                   bool                      `json:"array"`
 	APIParameterRestriction struct {
 		RangeRestriction struct {

--- a/api-endpoints-v2/resources.go
+++ b/api-endpoints-v2/resources.go
@@ -52,7 +52,7 @@ type ResourceSettings struct {
 
 func GetResources(endpointId int, version int) (*Resources, error) {
 	if version == 0 {
-		versions, err := ListVersions(&ListVersionsOptions{EndpointId: endpointId})
+		versions, err := ListVersions(endpointId)
 		if err != nil {
 			return nil, err
 		}

--- a/api-endpoints-v2/resources.go
+++ b/api-endpoints-v2/resources.go
@@ -139,8 +139,8 @@ func GetResourceMulti(endpointId int, resource string, version int) ([]ResourceB
 			}
 		}
 	} else {
-		if resource[len(resource)] == "*" {
-			resource = resource[len(resource)-1] + ".*"
+		if resource[len(resource):] == "*" {
+			resource = resource[:len(resource)-1] + ".*"
 		}
 		ret := []ResourceBaseInfo{}
 		for _, r := range *resources {

--- a/api-endpoints-v2/resources.go
+++ b/api-endpoints-v2/resources.go
@@ -3,10 +3,14 @@ package apiendpoints
 import (
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cast"
 )
 
 type Resources []ResourceBaseInfo
@@ -78,6 +82,22 @@ func GetResources(endpointId int, version int) (*Resources, error) {
 	}
 
 	return rep, nil
+}
+
+func (r *Resources) ToTable() *tablewriter.Table {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"ID", "Name", "Path", "Methods", "Private"})
+
+	for _, resource := range *r {
+		table.Append([]string{
+			cast.ToString(resource.APIResourceID),
+			cast.ToString(resource.APIResourceName),
+			cast.ToString(resource.ResourcePath),
+			cast.ToString(strings.Join(resource.APIResourceMethodsNameLists[:], ",")),
+			cast.ToString(resource.Private),
+		})
+	}
+	return table
 }
 
 func GetResource(endpointId int, resource string, version int) (*ResourceBaseInfo, error) {

--- a/api-endpoints-v2/resources.go
+++ b/api-endpoints-v2/resources.go
@@ -139,6 +139,9 @@ func GetResourceMulti(endpointId int, resource string, version int) ([]ResourceB
 			}
 		}
 	} else {
+		if resource[len(resource)] == "*" {
+			resource = resource[len(resource)-1] + ".*"
+		}
 		ret := []ResourceBaseInfo{}
 		for _, r := range *resources {
 			matched1, err := regexp.MatchString(resource, r.APIResourceName)

--- a/api-endpoints-v2/resources.go
+++ b/api-endpoints-v2/resources.go
@@ -51,17 +51,6 @@ type ResourceSettings struct {
 }
 
 func GetResources(endpointId int, version int) (*Resources, error) {
-	if version == 0 {
-		versions, err := ListVersions(endpointId)
-		if err != nil {
-			return nil, err
-		}
-
-		loc := len(versions.APIVersions) - 1
-		v := versions.APIVersions[loc]
-		version = v.VersionNumber
-	}
-
 	req, err := client.NewJSONRequest(
 		Config,
 		"GET",

--- a/api-endpoints-v2/resources.go
+++ b/api-endpoints-v2/resources.go
@@ -46,6 +46,17 @@ type ResourceSettings struct {
 }
 
 func GetResources(endpointId int, version int) (*Resources, error) {
+	if version == 0 {
+		versions, err := ListVersions(&ListVersionsOptions{EndpointId: endpointId})
+		if err != nil {
+			return nil, err
+		}
+
+		loc := len(versions.APIVersions) - 1
+		v := versions.APIVersions[loc]
+		version = v.VersionNumber
+	}
+
 	req, err := client.NewJSONRequest(
 		Config,
 		"GET",

--- a/api-endpoints-v2/resources.go
+++ b/api-endpoints-v2/resources.go
@@ -1,12 +1,15 @@
 package apiendpoints
 
 import (
+	"errors"
 	"fmt"
+	"regexp"
+	"strconv"
 
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
 )
 
-type Resources []Resource
+type Resources []ResourceBaseInfo
 
 type Resource struct {
 	APIResourceID           int     `json:"apiResourceId"`
@@ -24,25 +27,27 @@ type Resource struct {
 }
 
 type ResourceBaseInfo struct {
-	APIResourceClonedFromID *int    `json:"apiResourceClonedFromId"`
-	APIResourceID           int     `json:"apiResourceId"`
-	APIResourceLogicID      int     `json:"apiResourceLogicId"`
-	APIResourceName         string  `json:"apiResourceName"`
-	CreateDate              string  `json:"createDate"`
-	CreatedBy               string  `json:"createdBy"`
-	Description             *string `json:"description"`
-	Link                    *string `json:"link"`
-	LockVersion             int     `json:"lockVersion"`
-	Private                 bool    `json:"private"`
-	ResourcePath            string  `json:"resourcePath"`
-	UpdateDate              string  `json:"updateDate"`
-	UpdatedBy               string  `json:"updatedBy"`
+	APIResourceClonedFromID     *int     `json:"apiResourceClonedFromId"`
+	APIResourceID               int      `json:"apiResourceId"`
+	APIResourceLogicID          int      `json:"apiResourceLogicId"`
+	APIResourceName             string   `json:"apiResourceName"`
+	CreateDate                  string   `json:"createDate"`
+	CreatedBy                   string   `json:"createdBy"`
+	Description                 *string  `json:"description"`
+	Link                        *string  `json:"link"`
+	LockVersion                 int      `json:"lockVersion"`
+	Private                     bool     `json:"private"`
+	ResourcePath                string   `json:"resourcePath"`
+	UpdateDate                  string   `json:"updateDate"`
+	UpdatedBy                   string   `json:"updatedBy"`
+	APIResourceMethods          Methods  `json:"apiResourceMethods"`
+	APIResourceMethodsNameLists []string `json:"apiResourceMethodNameLists,omitempty"`
 }
 
 type ResourceSettings struct {
-	Path                 string        `json:"path"`
-	Methods              []MethodValue `json:"methods"`
-	InheritsFromEndpoint bool          `json:"inheritsFromEndpoint"`
+	Path                 string   `json:"path"`
+	Methods              []string `json:"methods"`
+	InheritsFromEndpoint bool     `json:"inheritsFromEndpoint"`
 }
 
 func GetResources(endpointId int, version int) (*Resources, error) {
@@ -84,4 +89,76 @@ func GetResources(endpointId int, version int) (*Resources, error) {
 	}
 
 	return rep, nil
+}
+
+func GetResource(endpointId int, resource string, version int) (*ResourceBaseInfo, error) {
+	resources, err := GetResources(endpointId, version)
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := strconv.Atoi(resource)
+	if err == nil {
+		for _, r := range *resources {
+			if id == r.APIResourceID {
+				return &r, nil
+			}
+		}
+	} else {
+		for _, r := range *resources {
+			matched1, err := regexp.MatchString(resource, r.APIResourceName)
+			if err != nil {
+				return nil, err
+			}
+
+			matched2, err := regexp.MatchString(resource, r.ResourcePath)
+			if err != nil {
+				return nil, err
+			}
+
+			if matched1 || matched2 {
+				return &r, nil
+			}
+		}
+	}
+
+	return nil, errors.New("Resource not found.")
+}
+
+func GetResourceMulti(endpointId int, resource string, version int) ([]ResourceBaseInfo, error) {
+	resources, err := GetResources(endpointId, version)
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := strconv.Atoi(resource)
+	if err == nil {
+		for _, r := range *resources {
+			if id == r.APIResourceID {
+				return []ResourceBaseInfo{r}, nil
+			}
+		}
+	} else {
+		ret := []ResourceBaseInfo{}
+		for _, r := range *resources {
+			matched1, err := regexp.MatchString(resource, r.APIResourceName)
+			if err != nil {
+				return nil, err
+			}
+
+			matched2, err := regexp.MatchString(resource, r.ResourcePath)
+			if err != nil {
+				return nil, err
+			}
+
+			if matched1 || matched2 {
+				ret = append(ret, r)
+			}
+		}
+		if len(ret) > 0 {
+			return ret, nil
+		}
+	}
+
+	return nil, errors.New("Resource not found.")
 }

--- a/api-endpoints-v2/versions.go
+++ b/api-endpoints-v2/versions.go
@@ -45,11 +45,7 @@ const (
 	StatusFailed      string = "FAILED"
 )
 
-type ListVersionsOptions struct {
-	EndpointId int
-}
-
-func ListVersions(options *ListVersionsOptions) (*Versions, error) {
+func ListVersions(endpointId int) (*Versions, error) {
 	req, err := client.NewJSONRequest(
 		Config,
 		"GET",
@@ -78,30 +74,14 @@ func ListVersions(options *ListVersionsOptions) (*Versions, error) {
 	return rep, nil
 }
 
-type GetVersionOptions struct {
-	EndpointId int
-	Version    int
-}
-
-func GetVersion(options *GetVersionOptions) (*Endpoint, error) {
-	if options.Version == 0 {
-		versions, err := ListVersions(&ListVersionsOptions{EndpointId: options.EndpointId})
-		if err != nil {
-			return nil, err
-		}
-
-		loc := len(versions.APIVersions) - 1
-		v := versions.APIVersions[loc]
-		options.Version = v.VersionNumber
-	}
-
+func GetVersion(endpointId, version int) (*Endpoint, error) {
 	req, err := client.NewJSONRequest(
 		Config,
 		"GET",
 		fmt.Sprintf(
 			"/api-definitions/v2/endpoints/%d/versions/%d/resources-detail",
-			options.EndpointId,
-			options.Version,
+			endpointId,
+			version,
 		),
 		nil,
 	)
@@ -124,19 +104,14 @@ func ModifyVersion(endpoint *Endpoint) (*Endpoint, error) {
 	return call(req, err)
 }
 
-type CloneVersionOptions struct {
-	EndpointId int
-	Version    int
-}
-
-func CloneVersion(options *CloneVersionOptions) (*Endpoint, error) {
+func CloneVersion(endpointId, version int) (*Endpoint, error) {
 	req, err := client.NewJSONRequest(
 		Config,
 		"POST",
 		fmt.Sprintf(
 			"/api-definitions/v2/endpoints/%d/versions/%d/cloneVersion",
-			options.EndpointId,
-			options.Version,
+			endpointId,
+			version,
 		),
 		options,
 	)
@@ -144,19 +119,14 @@ func CloneVersion(options *CloneVersionOptions) (*Endpoint, error) {
 	return call(req, err)
 }
 
-type RemoveVersionOptions struct {
-	EndpointId    int
-	VersionNumber int
-}
-
-func RemoveVersion(options *RemoveVersionOptions) (*Endpoint, error) {
+func RemoveVersion(endpointId, version int) (*Endpoint, error) {
 	req, err := client.NewJSONRequest(
 		Config,
 		"DELETE",
 		fmt.Sprintf(
 			"/api-definitions/v2/endpoints/%d/versions/%d",
-			options.EndpointId,
-			options.VersionNumber,
+			endpointId,
+			version,
 		),
 		nil,
 	)
@@ -165,7 +135,7 @@ func RemoveVersion(options *RemoveVersionOptions) (*Endpoint, error) {
 }
 
 func GetLatestVersionNumber(endpointId int) (int, error) {
-	versions, err := ListVersions(&ListVersionsOptions{EndpointId: endpointId})
+	versions, err := ListVersions(endpointId)
 	if err != nil {
 		return 0, err
 	}

--- a/api-endpoints-v2/versions.go
+++ b/api-endpoints-v2/versions.go
@@ -51,7 +51,7 @@ func ListVersions(endpointId int) (*Versions, error) {
 		"GET",
 		fmt.Sprintf(
 			"/api-definitions/v2/endpoints/%d/versions",
-			options.EndpointId,
+			endpointId,
 		),
 		nil,
 	)
@@ -113,7 +113,7 @@ func CloneVersion(endpointId, version int) (*Endpoint, error) {
 			endpointId,
 			version,
 		),
-		options,
+		nil,
 	)
 
 	return call(req, err)

--- a/api-endpoints-v2/versions.go
+++ b/api-endpoints-v2/versions.go
@@ -163,3 +163,14 @@ func RemoveVersion(options *RemoveVersionOptions) (*Endpoint, error) {
 
 	return call(req, err)
 }
+
+func GetLatestVersionNumber(endpointId int) (int, error) {
+	versions, err := ListVersions(&ListVersionsOptions{EndpointId: endpointId})
+	if err != nil {
+		return 0, err
+	}
+
+	loc := len(versions.APIVersions) - 1
+	v := versions.APIVersions[loc]
+	return v.VersionNumber, nil
+}

--- a/api-endpoints-v2/versions.go
+++ b/api-endpoints-v2/versions.go
@@ -13,37 +13,28 @@ type Versions struct {
 }
 
 type Version struct {
-	CreatedBy            string       `json:"createdBy"`
-	CreateDate           string       `json:"createDate"`
-	UpdateDate           string       `json:"updateDate"`
-	UpdatedBy            string       `json:"updatedBy"`
-	APIEndPointVersionID int          `json:"apiEndPointVersionId"`
-	BasePath             string       `json:"basePath"`
-	Description          *string      `json:"description`
-	BasedOn              *int         `json:"basedOn"`
-	StagingStatus        *StatusValue `json:"stagingStatus"`
-	ProductionStatus     *StatusValue `json:"productionStatus"`
-	StagingDate          *string      `json:"stagingDate"`
-	ProductionDate       *string      `json:"productionDate"`
-	IsVersionLocked      bool         `json:"isVersionLocked"`
-	AvailableActions     []string     `json:"availableActions"`
-	VersionNumber        int          `json:"versionNumber"`
-	LockVersion          int          `json:"lockVersion"`
+	CreatedBy            string   `json:"createdBy"`
+	CreateDate           string   `json:"createDate"`
+	UpdateDate           string   `json:"updateDate"`
+	UpdatedBy            string   `json:"updatedBy"`
+	APIEndPointVersionID int      `json:"apiEndPointVersionId"`
+	BasePath             string   `json:"basePath"`
+	Description          *string  `json:"description`
+	BasedOn              *int     `json:"basedOn"`
+	StagingStatus        string   `json:"stagingStatus"`
+	ProductionStatus     string   `json:"productionStatus"`
+	StagingDate          *string  `json:"stagingDate"`
+	ProductionDate       *string  `json:"productionDate"`
+	IsVersionLocked      bool     `json:"isVersionLocked"`
+	AvailableActions     []string `json:"availableActions"`
+	VersionNumber        int      `json:"versionNumber"`
+	LockVersion          int      `json:"lockVersion"`
 }
 
 type VersionSummary struct {
-	Status        StatusValue `json:"status,omitempty"`
-	VersionNumber int         `json:"versionNumber,omitempty"`
+	Status        string `json:"status,omitempty"`
+	VersionNumber int    `json:"versionNumber,omitempty"`
 }
-
-type StatusValue string
-
-const (
-	StatusPending     string = "PENDING"
-	StatusActive      string = "ACTIVE"
-	StatusDeactivated string = "DEACTIVATED"
-	StatusFailed      string = "FAILED"
-)
 
 func ListVersions(endpointId int) (*Versions, error) {
 	req, err := client.NewJSONRequest(

--- a/apikey-manager-v1/collections.go
+++ b/apikey-manager-v1/collections.go
@@ -224,12 +224,12 @@ func CollectionAclDeny(collectionId int, acl []string) (*Collection, error) {
 		return collection, err
 	}
 
-	for cIndex, currentAcl := range collection.GrantedACL {
+	for i := len(collection.GrantedACL) - 1; i >= 0; i-- {
 		for _, newAcl := range acl {
-			if newAcl == currentAcl {
+			if newAcl == collection.GrantedACL[i] {
 				collection.GrantedACL = append(
-					collection.GrantedACL[:cIndex],
-					collection.GrantedACL[cIndex+1:]...,
+					collection.GrantedACL[:i],
+					collection.GrantedACL[i+1:]...,
 				)
 			}
 		}

--- a/apikey-manager-v1/collections.go
+++ b/apikey-manager-v1/collections.go
@@ -202,26 +202,27 @@ func CollectionAclDeny(collectionId int, acl []string) (*Collection, error) {
 }
 
 type Quota struct {
-	Enabled  bool   `json:"enabled,omitempty"`
-	Value    int    `json:"value,omitempty"`
-	Interval string `json:"interval,omitempty"`
+	Enabled  bool   `json:"enabled"`
+	Value    int    `json:"value"`
+	Interval string `json:"interval"`
 	Headers  struct {
-		DenyLimitHeaderShown      bool `json:"denyLimitHeaderShown,omitempty"`
-		DenyRemainingHeaderShown  bool `json:"denyRemainingHeaderShown,omitempty"`
-		DenyNextHeaderShown       bool `json:"denyNextHeaderShown,omitempty"`
-		AllowLimitHeaderShown     bool `json:"allowLimitHeaderShown,omitempty"`
-		AllowRemainingHeaderShown bool `json:"allowRemainingHeaderShown,omitempty"`
-		AllowResetHeaderShown     bool `json:"allowResetHeaderShown,omitempty"`
+		DenyLimitHeaderShown      bool `json:"denyLimitHeaderShown"`
+		DenyRemainingHeaderShown  bool `json:"denyRemainingHeaderShown"`
+		DenyNextHeaderShown       bool `json:"denyNextHeaderShown"`
+		AllowLimitHeaderShown     bool `json:"allowLimitHeaderShown"`
+		AllowRemainingHeaderShown bool `json:"allowRemainingHeaderShown"`
+		AllowResetHeaderShown     bool `json:"allowResetHeaderShown"`
 	} `json:"headers,omitempty"`
 }
 
-func CollectionSetQuota(collectionId int, value int) (*Collection, error) {
+func CollectionSetQuota(collectionId int, limit int, interval string) (*Collection, error) {
 	collection, err := GetCollection(collectionId)
 	if err != nil {
 		return collection, err
 	}
 
-	collection.Quota.Value = value
+	collection.Quota.Value = limit
+	collection.Quota.Interval = interval
 	req, err := client.NewJSONRequest(
 		Config,
 		"PUT",

--- a/apikey-manager-v1/collections.go
+++ b/apikey-manager-v1/collections.go
@@ -1,7 +1,10 @@
 package apikeymanager
 
 import (
+	"errors"
 	"fmt"
+	"regexp"
+	"strconv"
 
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
 )
@@ -116,6 +119,66 @@ func GetCollection(collectionId int) (*Collection, error) {
 	}
 
 	return rep, nil
+}
+
+func GetCollectionMulti(collection string) (*Collections, error) {
+	id, err := strconv.Atoi(collection)
+	if err == nil {
+		req, err := client.NewJSONRequest(
+			Config,
+			"GET",
+			fmt.Sprintf("/apikey-manager-api/v1/collections/%d", id),
+			nil,
+		)
+
+		if err != nil {
+			return nil, err
+		}
+
+		res, err := client.Do(Config, req)
+
+		if err != nil {
+			return nil, err
+		}
+
+		if client.IsError(res) {
+			return nil, client.NewAPIError(res)
+		}
+
+		rep := &Collection{}
+		if err = client.BodyJSON(res, rep); err != nil {
+			return nil, err
+		}
+
+		return &Collections{*rep}, nil
+	} else {
+		collections, err := ListCollections()
+		if err != nil {
+			return nil, err
+		}
+
+		if collection[len(collection):] == "*" {
+			collection = collection[:len(collection)-1] + ".*"
+		}
+
+		ret := Collections{}
+		for _, r := range *collections {
+			matched, err := regexp.MatchString(collection, r.Name)
+			if err != nil {
+				return nil, err
+			}
+
+			if matched {
+				ret = append(ret, r)
+			}
+		}
+
+		if len(ret) > 0 {
+			return &ret, nil
+		}
+
+		return nil, errors.New("Collection not found.")
+	}
 }
 
 func CollectionAclAllow(collectionId int, acl []string) (*Collection, error) {

--- a/apikey-manager-v1/collections.go
+++ b/apikey-manager-v1/collections.go
@@ -360,12 +360,12 @@ func CollectionSetQuota(collection string, limit int, interval string) (*Collect
 			return nil, client.NewAPIError(res)
 		}
 
-		rep := Collection{}
+		rep := &Collection{}
 		if err = client.BodyJSON(res, rep); err != nil {
 			return nil, err
 		}
 
-		rcollections = append(rcollections, rep)
+		rcollections = append(rcollections, *rep)
 	}
 
 	return &rcollections, nil

--- a/apikey-manager-v1/collections.go
+++ b/apikey-manager-v1/collections.go
@@ -339,6 +339,13 @@ func CollectionSetQuota(collection string, limit int, interval string) (*Collect
 	for _, collection := range *collections {
 		collection.Quota.Value = limit
 		collection.Quota.Interval = interval
+		collection.Quota.Enabled = true
+		collection.Quota.DenyLimitHeaderShown = true
+		collection.Quota.DenyRemainingHeaderShown = true
+		collection.Quota.DenyNextHeaderShown = true
+		collection.Quota.AllowLimitHeaderShown = true
+		collection.Quota.AllowRemainingHeaderShown = true
+		collection.Quota.AllowResetHeaderShown = true
 		req, err := client.NewJSONRequest(
 			Config,
 			"PUT",

--- a/apikey-manager-v1/collections.go
+++ b/apikey-manager-v1/collections.go
@@ -3,10 +3,14 @@ package apikeymanager
 import (
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cast"
 )
 
 type Collections []Collection
@@ -52,6 +56,30 @@ func ListCollections() (*Collections, error) {
 	}
 
 	return rep, nil
+}
+
+func (c *Collections) ToTable() *tablewriter.Table {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{
+		"ID",
+		"Name",
+		"Granted ACL",
+		"Quota Enabled",
+		"Quota Value",
+		"Quota Interval",
+	})
+
+	for _, collection := range *c {
+		table.Append([]string{
+			cast.ToString(collection.Id),
+			cast.ToString(collection.Name),
+			cast.ToString(strings.Join(collection.GrantedACL[:], ",")),
+			cast.ToString(collection.Quota.Enabled),
+			cast.ToString(collection.Quota.Value),
+			cast.ToString(collection.Quota.Interval),
+		})
+	}
+	return table
 }
 
 type CreateCollectionOptions struct {
@@ -119,6 +147,29 @@ func GetCollection(collectionId int) (*Collection, error) {
 	}
 
 	return rep, nil
+}
+
+func (collection *Collection) ToTable() *tablewriter.Table {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{
+		"ID",
+		"Name",
+		"Granted ACL",
+		"Quota Enabled",
+		"Quota Value",
+		"Quota Interval",
+	})
+
+	table.Append([]string{
+		cast.ToString(collection.Id),
+		cast.ToString(collection.Name),
+		cast.ToString(strings.Join(collection.GrantedACL[:], ",")),
+		cast.ToString(collection.Quota.Enabled),
+		cast.ToString(collection.Quota.Value),
+		cast.ToString(collection.Quota.Interval),
+	})
+
+	return table
 }
 
 func GetCollectionMulti(collection string) (*Collections, error) {

--- a/apikey-manager-v1/collections.go
+++ b/apikey-manager-v1/collections.go
@@ -340,12 +340,12 @@ func CollectionSetQuota(collection string, limit int, interval string) (*Collect
 		collection.Quota.Value = limit
 		collection.Quota.Interval = interval
 		collection.Quota.Enabled = true
-		collection.Quota.DenyLimitHeaderShown = true
-		collection.Quota.DenyRemainingHeaderShown = true
-		collection.Quota.DenyNextHeaderShown = true
-		collection.Quota.AllowLimitHeaderShown = true
-		collection.Quota.AllowRemainingHeaderShown = true
-		collection.Quota.AllowResetHeaderShown = true
+		collection.Quota.Headers.DenyLimitHeaderShown = true
+		collection.Quota.Headers.DenyRemainingHeaderShown = true
+		collection.Quota.Headers.DenyNextHeaderShown = true
+		collection.Quota.Headers.AllowLimitHeaderShown = true
+		collection.Quota.Headers.AllowRemainingHeaderShown = true
+		collection.Quota.Headers.AllowResetHeaderShown = true
 		req, err := client.NewJSONRequest(
 			Config,
 			"PUT",

--- a/apikey-manager-v1/keys.go
+++ b/apikey-manager-v1/keys.go
@@ -3,8 +3,11 @@ package apikeymanager
 import (
 	"encoding/json"
 	"io/ioutil"
+	"os"
 
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cast"
 )
 
 type Keys []int
@@ -69,6 +72,28 @@ func CollectionAddKey(collectionId int, name, value string) (*Key, error) {
 	}
 
 	return rep, nil
+}
+
+func (k *Key) ToTable() *tablewriter.Table {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{
+		"ID",
+		"Name",
+		"Value",
+		"Collection ID",
+		"Quota Usage",
+		"Revoked",
+	})
+
+	table.Append([]string{
+		cast.ToString(k.Id),
+		cast.ToString(k.Label),
+		cast.ToString(k.Value),
+		cast.ToString(k.CollectionId),
+		cast.ToString(k.QuotaUsage),
+		cast.ToString(k.Revoked),
+	})
+	return table
 }
 
 type ImportKey struct {


### PR DESCRIPTION
This adds support for the API Endpoints V2 API including API Gateway and Key and Quota Management. This is implemented in 3 new [CLI commands](https://github.com/akamai/cli-api-gateway) - `api-gateway`, `api-keys`, and `api-security`.