### PR TITLE
fix: methods to remove cname and non cname.

### DIFF
--- a/configdns-v1/zone.go
+++ b/configdns-v1/zone.go
@@ -786,21 +786,24 @@ func (zone *Zone) validateCnames() (bool, []name) {
 }
 
 func (zone *Zone) removeCnameName(host string) {
-	for i, v := range cnameNames {
-		if v.name == host {
-			r := cnameNames[:i]
-			cnameNames = append(r, cnameNames[i+1:]...)
+	var ncn []name
+	for _, v := range cnameNames {
+		if v.name != host {
+			ncn =append(ncn, v)
 		}
 	}
+	cnameNames = ncn
 }
 
+
 func (zone *Zone) removeNonCnameName(host string) {
-	for i, v := range nonCnameNames {
-		if v.name == host {
-			r := nonCnameNames[:i]
-			nonCnameNames = append(r, nonCnameNames[i+1:]...)
+	var ncn []name
+	for _, v := range nonCnameNames {
+		if v.name != host {
+			ncn =append(ncn, v)
 		}
 	}
+	nonCnameNames = ncn
 }
 
 func (zone *Zone) FindRecords(recordType string, options map[string]interface{}) []DNSRecord {

--- a/configdns-v1/zone_test.go
+++ b/configdns-v1/zone_test.go
@@ -263,6 +263,49 @@ func TestZone_AddRecord(t *testing.T) {
 	assert.Equal(t, records, zone.Zone.A)
 }
 
+func Test_removeNonCnameName(t *testing.T) {
+	backup := nonCnameNames
+	defer func() {
+		nonCnameNames = backup
+	}()
+
+
+	names := []name{
+		{recordType: "TXT", name: "test.com"},
+		{recordType: "TXT", name: "foo.com"},
+		{recordType: "TXT", name: "bar.com"},
+		{recordType: "TXT", name: "test.com"},
+	}
+
+	for _, n := range names {
+		nonCnameNames = append(nonCnameNames,  n)
+	}
+
+	zone := Zone{}
+	zone.removeNonCnameName("test.com")
+}
+
+func Test_removeCnameName(t *testing.T) {
+	backup := cnameNames
+	defer func() {
+		cnameNames = backup
+	}()
+
+	names := []name{
+		{recordType: "TXT", name: "test.com"},
+		{recordType: "TXT", name: "foo.com"},
+		{recordType: "TXT", name: "bar.com"},
+		{recordType: "TXT", name: "test.com"},
+	}
+
+	for _, n := range names {
+		cnameNames = append(cnameNames,  n)
+	}
+
+	zone := Zone{}
+	zone.removeCnameName("test.com")
+}
+
 func testZone_AddRecord_Provider() []*ARecord {
 	return []*ARecord{
 		&ARecord{


### PR DESCRIPTION
`cnameNames` or `nonCnameNames` can have several values with the same identifier, so the current algorithm produce a panic.

```
panic: runtime error: slice bounds out of range [recovered]
	panic: runtime error: slice bounds out of range

goroutine 5 [running]:
testing.tRunner.func1(0xc00011e100)
	/home/ldez/.gvm/gos/go1.11.4/src/testing/testing.go:792 +0x387
panic(0x6ec800, 0x998c30)
	/home/ldez/.gvm/gos/go1.11.4/src/runtime/panic.go:513 +0x1b9
github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v1.(*Zone).removeNonCnameName(0xc000055d90, 0x748317, 0x8)
	/home/ldez/sources/go/src/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v1/zone.go:801 +0x24f
github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v1.Test_removeNonCnameName(0xc00011e100)
	/home/ldez/sources/go/src/github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v1/zone_test.go:285 +0x160
testing.tRunner(0xc00011e100, 0x75f888)
	/home/ldez/.gvm/gos/go1.11.4/src/testing/testing.go:827 +0xbf
created by testing.(*T).Run
	/home/ldez/.gvm/gos/go1.11.4/src/testing/testing.go:878 +0x35c
```

https://github.com/xenolf/lego/issues/763#issuecomment-456760192