### PR TITLE
Release/2.0.0

### DIFF
--- a/pkg/configdns/record_lookup_test.go
+++ b/pkg/configdns/record_lookup_test.go
@@ -128,7 +128,7 @@ func TestDns_GetRecordList(t *testing.T) {
         }
     ]
 }`,
-			expectedPath: "/config-dns/v2/zones/example.com/recordsets?types=A&showAll=true",
+			expectedPath: "/config-dns/v2/zones/example.com/recordsets?showAll=true&types=A",
 			expectedResponse: &RecordSetResponse{
 				Metadata: MetadataH{
 					LastPage:      0,
@@ -158,7 +158,7 @@ func TestDns_GetRecordList(t *testing.T) {
     "detail": "Error fetching authorities",
     "status": 500
 }`,
-			expectedPath: "/config-dns/v2/zones/example.com/recordsets?types=A&showAll=true",
+			expectedPath: "/config-dns/v2/zones/example.com/recordsets?showAll=true&types=A",
 			withError: &Error{
 				Type:       "internal_error",
 				Title:      "Internal Server Error",
@@ -227,7 +227,7 @@ func TestDns_GetRdata(t *testing.T) {
 		}
     ]
 }`,
-			expectedPath:     "/config-dns/v2/zones/example.com/recordsets?types=AAAA&showAll=true",
+			expectedPath:     "/config-dns/v2/zones/example.com/recordsets?showAll=true&types=AAAA",
 			expectedResponse: []string{"2001:0db8:85a3:0000:0000:8a2e:0370:7334"},
 		},
 		"loc test": {
@@ -257,7 +257,7 @@ func TestDns_GetRdata(t *testing.T) {
         }
     ]
 }`,
-			expectedPath:     "/config-dns/v2/zones/example.com/recordsets?types=LOC&showAll=true",
+			expectedPath:     "/config-dns/v2/zones/example.com/recordsets?showAll=true&types=LOC",
 			expectedResponse: []string{"52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000.00m 10.00m"},
 		},
 		"500 internal server error": {
@@ -271,7 +271,7 @@ func TestDns_GetRdata(t *testing.T) {
     "detail": "Error fetching authorities",
     "status": 500
 }`,
-			expectedPath: "/config-dns/v2/zones/example.com/recordsets?types=A&showAll=true",
+			expectedPath: "/config-dns/v2/zones/example.com/recordsets?showAll=true&types=A",
 			withError: &Error{
 				Type:       "internal_error",
 				Title:      "Internal Server Error",

--- a/pkg/configdns/zone.go
+++ b/pkg/configdns/zone.go
@@ -163,7 +163,7 @@ var zoneStructMap map[string]string = map[string]string{
 	"SignAndServeAlgorithm": "signAndServeAlgorithm",
 	"TsigKey":               "tsigKey",
 	"Target":                "target",
-	"EndCustomerId":         "endCustomerId",
+	"EndCustomerID":         "endCustomerId",
 	"ContractId":            "contractId"}
 
 // Util to convert struct to http request body, eg. io.reader

--- a/pkg/configgtm/datacenter.go
+++ b/pkg/configgtm/datacenter.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"strconv"
-	"strings"
 )
 
 //
@@ -209,7 +208,9 @@ func createDefaultDC(ctx context.Context, p *gtm, defaultID int, domainName stri
 	if err == nil {
 		return dc, err
 	} else {
-		if !strings.Contains(err.Error(), "not found") || !strings.Contains(err.Error(), "Datacenter") {
+		apiError, ok := err.(*Error)
+		//if !strings.Contains(err.Error(), "not found") || !strings.Contains(err.Error(), "Datacenter") {
+		if !ok || apiError.StatusCode != http.StatusNotFound {
 			return nil, err
 		}
 	}

--- a/pkg/session/request.go
+++ b/pkg/session/request.go
@@ -87,7 +87,9 @@ func (s *session) Exec(r *http.Request, out interface{}, in ...interface{}) (*ht
 		}
 	}
 
-	if out != nil && resp.StatusCode < http.StatusMultipleChoices {
+	if out != nil &&
+		resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices &&
+		resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusResetContent {
 		data, err := ioutil.ReadAll(resp.Body)
 		resp.Body = ioutil.NopCloser(bytes.NewBuffer(data))
 		if err != nil {

--- a/pkg/session/request.go
+++ b/pkg/session/request.go
@@ -87,7 +87,7 @@ func (s *session) Exec(r *http.Request, out interface{}, in ...interface{}) (*ht
 		}
 	}
 
-	if out != nil {
+	if out != nil && resp.StatusCode < http.StatusMultipleChoices {
 		data, err := ioutil.ReadAll(resp.Body)
 		resp.Body = ioutil.NopCloser(bytes.NewBuffer(data))
 		if err != nil {


### PR DESCRIPTION
Fix tests in dns package with wrong argument order
Correct default datacenter create argument evaluation
Ensure http response status is in valid range before processing entity to avoid crash