### PR TITLE
Release/v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # EDGEGRID GOLANG RELEASE NOTES
 
+## 2.0.3 (Dec 7, 2020)
+* PAPI - Property hostname validation fix for missing hostnames.  
+* PAPI - fix minor typo in rules error messages
+
 ## 2.0.2 (Nov 19, 2020)
 * [IMPORTANT] APPSEC - Added Application Security API
 * [ENHANCEMENT] DNS - Bulk Api endpoints added

--- a/pkg/papi/propertyhostname.go
+++ b/pkg/papi/propertyhostname.go
@@ -98,7 +98,6 @@ func (ch UpdatePropertyVersionHostnamesRequest) Validate() error {
 	return validation.Errors{
 		"PropertyID":      validation.Validate(ch.PropertyID, validation.Required),
 		"PropertyVersion": validation.Validate(ch.PropertyVersion, validation.Required),
-		"Hostnames":       validation.Validate(ch.Hostnames, validation.Required),
 	}.Filter()
 }
 
@@ -163,7 +162,11 @@ func (p *papi) UpdatePropertyVersionHostnames(ctx context.Context, params Update
 	}
 
 	var hostnames UpdatePropertyVersionHostnamesResponse
-	resp, err := p.Exec(req, &hostnames, params.Hostnames)
+	newHostnames := params.Hostnames
+	if newHostnames == nil {
+		newHostnames = []Hostname{}
+	}
+	resp, err := p.Exec(req, &hostnames, newHostnames)
 	if err != nil {
 		return nil, fmt.Errorf("%w: request failed: %s", ErrUpdatePropertyVersionHostnames, err)
 	}

--- a/pkg/papi/propertyhostname_test.go
+++ b/pkg/papi/propertyhostname_test.go
@@ -202,7 +202,6 @@ func TestPapi_UpdatePropertyVersionHostnames(t *testing.T) {
         ]
     }
 }
-
 `,
 			expectedPath: "/papi/v1/properties/prp_175780/versions/3/hostnames?contractId=ctr_1-1TJZH5&groupId=grp_15225&validateHostnames=false",
 			expectedResponse: &UpdatePropertyVersionHostnamesResponse{
@@ -289,7 +288,6 @@ func TestPapi_UpdatePropertyVersionHostnames(t *testing.T) {
         "items": []
     }
 }
-
 `,
 			expectedPath: "/papi/v1/properties/prp_175780/versions/3/hostnames?contractId=ctr_1-1TJZH5&groupId=grp_15225&validateHostnames=true",
 			expectedResponse: &UpdatePropertyVersionHostnamesResponse{
@@ -326,38 +324,108 @@ func TestPapi_UpdatePropertyVersionHostnames(t *testing.T) {
 				assert.Contains(t, err.Error(), "PropertyVersion")
 			},
 		},
-		"validation error Hostnames missing": {
+		"200 Hostnames missing": {
 			params: UpdatePropertyVersionHostnamesRequest{
 				PropertyID:      "prp_175780",
 				PropertyVersion: 3,
+				GroupID:         "grp_15225",
+				ContractID:      "ctr_1-1TJZH5",
 			},
-			withError: func(t *testing.T, err error) {
-				want := ErrStructValidation
-				assert.True(t, errors.Is(err, want), "want: %s; got: %s", want, err)
-				assert.Contains(t, err.Error(), "Hostnames")
+			responseStatus: http.StatusOK,
+			responseBody: `
+{
+	"accountId": "act_1-1TJZFB",
+	"contractId": "ctr_1-1TJZH5",
+	"groupId": "grp_15225",
+	"propertyId": "prp_175780",
+	"propertyVersion": 3,
+	"etag": "6aed418629b4e5c0",
+	"validateHostnames": false,
+	"hostnames": {
+		"items": []
+	}
+}`,
+			expectedPath: "/papi/v1/properties/prp_175780/versions/3/hostnames?contractId=ctr_1-1TJZH5&groupId=grp_15225&validateHostnames=false",
+			expectedResponse: &UpdatePropertyVersionHostnamesResponse{
+				AccountID:       "act_1-1TJZFB",
+				ContractID:      "ctr_1-1TJZH5",
+				GroupID:         "grp_15225",
+				PropertyID:      "prp_175780",
+				PropertyVersion: 3,
+				Etag:            "6aed418629b4e5c0",
+				Hostnames: HostnameResponseItems{
+					Items: []Hostname{},
+				},
 			},
 		},
-		"validation error Hostnames items missing": {
+		"200 Hostnames items missing": {
 			params: UpdatePropertyVersionHostnamesRequest{
 				PropertyID:      "prp_175780",
 				PropertyVersion: 3,
+				GroupID:         "grp_15225",
+				ContractID:      "ctr_1-1TJZH5",
+				Hostnames:       nil,
 			},
-			withError: func(t *testing.T, err error) {
-				want := ErrStructValidation
-				assert.True(t, errors.Is(err, want), "want: %s; got: %s", want, err)
-				assert.Contains(t, err.Error(), "Hostnames")
+			responseStatus: http.StatusOK,
+			responseBody: `
+{
+	"accountId": "act_1-1TJZFB",
+	"contractId": "ctr_1-1TJZH5",
+	"groupId": "grp_15225",
+	"propertyId": "prp_175780",
+	"propertyVersion": 3,
+	"etag": "6aed418629b4e5c0",
+	"validateHostnames": false,
+	"hostnames": {
+		"items": []
+	}
+}`,
+			expectedPath: "/papi/v1/properties/prp_175780/versions/3/hostnames?contractId=ctr_1-1TJZH5&groupId=grp_15225&validateHostnames=false",
+			expectedResponse: &UpdatePropertyVersionHostnamesResponse{
+				AccountID:       "act_1-1TJZFB",
+				ContractID:      "ctr_1-1TJZH5",
+				GroupID:         "grp_15225",
+				PropertyID:      "prp_175780",
+				PropertyVersion: 3,
+				Etag:            "6aed418629b4e5c0",
+				Hostnames: HostnameResponseItems{
+					Items: []Hostname{},
+				},
 			},
 		},
-		"validation error Hostnames items empty": {
+		"200 Hostnames items empty": {
 			params: UpdatePropertyVersionHostnamesRequest{
 				PropertyID:      "prp_175780",
 				PropertyVersion: 3,
+				GroupID:         "grp_15225",
+				ContractID:      "ctr_1-1TJZH5",
 				Hostnames:       []Hostname{},
 			},
-			withError: func(t *testing.T, err error) {
-				want := ErrStructValidation
-				assert.True(t, errors.Is(err, want), "want: %s; got: %s", want, err)
-				assert.Contains(t, err.Error(), "Hostnames")
+			responseStatus: http.StatusOK,
+			responseBody: `
+{
+	"accountId": "act_1-1TJZFB",
+	"contractId": "ctr_1-1TJZH5",
+	"groupId": "grp_15225",
+	"propertyId": "prp_175780",
+	"propertyVersion": 3,
+	"etag": "6aed418629b4e5c0",
+	"validateHostnames": false,
+	"hostnames": {
+		"items": []
+	}
+}`,
+			expectedPath: "/papi/v1/properties/prp_175780/versions/3/hostnames?contractId=ctr_1-1TJZH5&groupId=grp_15225&validateHostnames=false",
+			expectedResponse: &UpdatePropertyVersionHostnamesResponse{
+				AccountID:       "act_1-1TJZFB",
+				ContractID:      "ctr_1-1TJZH5",
+				GroupID:         "grp_15225",
+				PropertyID:      "prp_175780",
+				PropertyVersion: 3,
+				Etag:            "6aed418629b4e5c0",
+				Hostnames: HostnameResponseItems{
+					Items: []Hostname{},
+				},
 			},
 		},
 		"500 internal server status error": {

--- a/pkg/papi/propertyversion.go
+++ b/pkg/papi/propertyversion.go
@@ -153,6 +153,8 @@ const (
 	VersionStatusInactive VersionStatus = "INACTIVE"
 	// VersionStatusPending const
 	VersionStatusPending VersionStatus = "PENDING"
+	// ActivationStatusDeactivated is deactivated
+	VersionStatusDeactivated VersionStatus = "DEACTIVATED"
 	// VersionProduction const
 	VersionProduction = "PRODUCTION"
 	// VersionStaging const

--- a/pkg/papi/rule.go
+++ b/pkg/papi/rule.go
@@ -206,7 +206,7 @@ func (v RuleVariable) Validate() error {
 }
 
 var (
-	ErrGetRuleTree    = errors.New("fetchign rule tree")
+	ErrGetRuleTree    = errors.New("fetching rule tree")
 	ErrUpdateRuleTree = errors.New("updating rule tree")
 )
 


### PR DESCRIPTION
## 2.0.3 (Dec 7, 2020)
* PAPI - Property hostname validation fix for missing hostnames.  
* PAPI - fix minor typo in rules error messages