### PR TITLE
GTM API v1.5 support

### DIFF
--- a/configgtm-v1_5/README.md
+++ b/configgtm-v1_5/README.md
@@ -1,0 +1,2 @@
+# Akamai Config GTM (Global Traffic Management)
+A golang package that talks to the [Akamai OPEN Config GTM API](https://developer.akamai.com/api/luna/config-gtm/overview.html).

--- a/configgtm-v1_5/asmap.go
+++ b/configgtm-v1_5/asmap.go
@@ -1,0 +1,204 @@
+package configgtm
+
+import (
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
+
+	"fmt"
+)
+
+//
+// Handle Operations on gtm asmaps
+// Based on 1.4 schema
+//
+
+// AsAssignment represents a GTM asmap assignment structure
+type AsAssignment struct {
+	DatacenterBase
+	AsNumbers []int64 `json:"asNumbers"`
+}
+
+// AsMap  represents a GTM AsMap
+type AsMap struct {
+	DefaultDatacenter *DatacenterBase `json:"defaultDatacenter"`
+	Assignments       []*AsAssignment `json:"assignments,omitempty"`
+	Name              string          `json:"name"`
+	Links             []*Link         `json:"links,omitempty"`
+}
+
+// NewAsMap creates a new asMap
+func NewAsMap(name string) *AsMap {
+	asmap := &AsMap{Name: name}
+	return asmap
+}
+
+// GetAsMap retrieves a asMap with the given name.
+func GetAsMap(name, domainName string) (*AsMap, error) {
+	as := NewAsMap(name)
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/as-maps/%s", domainName, name),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	printHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, CommonError{entityName: "asMap", name: name}
+	} else {
+		err = client.BodyJSON(res, as)
+		if err != nil {
+			return nil, err
+		}
+
+		return as, nil
+	}
+}
+
+// Instantiate new Assignment struct
+func (as *AsMap) NewAssignment(dcID int, nickname string) *AsAssignment {
+	asAssign := &AsAssignment{}
+	asAssign.DatacenterId = dcID
+	asAssign.Nickname = nickname
+
+	return asAssign
+
+}
+
+// Instantiate new Default Datacenter Struct
+func (as *AsMap) NewDefaultDatacenter(dcID int) *DatacenterBase {
+	return &DatacenterBase{DatacenterId: dcID}
+}
+
+// Create asMap in provided domain
+func (as *AsMap) Create(domainName string) (*AsMapResponse, error) {
+
+	// Use common code. Any specific validation needed?
+
+	return as.save(domainName)
+
+}
+
+// Update AsMap in given domain
+func (as *AsMap) Update(domainName string) (*ResponseStatus, error) {
+
+	// common code
+
+	stat, err := as.save(domainName)
+	if err != nil {
+		return nil, err
+	}
+	return stat.Status, err
+
+}
+
+// Save AsMap in given domain. Common path for Create and Update.
+func (as *AsMap) save(domainName string) (*AsMapResponse, error) {
+
+	req, err := client.NewJSONRequest(
+		Config,
+		"PUT",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/as-maps/%s", domainName, as.Name),
+		as,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+
+	// Network error
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "asMap",
+			name:             as.Name,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	printHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "asMap", name: as.Name, apiErrorMessage: err.Detail, err: err}
+	}
+
+	responseBody := &AsMapResponse{}
+	// Unmarshall whole response body for updated entity and in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody, nil
+}
+
+// Delete AsMap method
+func (as *AsMap) Delete(domainName string) (*ResponseStatus, error) {
+
+	req, err := client.NewRequest(
+		Config,
+		"DELETE",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/as-maps/%s", domainName, as.Name),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Network error
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "asMap",
+			name:             as.Name,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	printHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "asMap", name: as.Name, apiErrorMessage: err.Detail, err: err}
+	}
+
+	responseBody := &ResponseBody{}
+	// Unmarshall whole response body in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody.Status, nil
+}

--- a/configgtm-v1_5/asmap.go
+++ b/configgtm-v1_5/asmap.go
@@ -8,7 +8,7 @@ import (
 
 //
 // Handle Operations on gtm asmaps
-// Based on 1.4 schema
+// Based on 1.5 schema
 //
 
 // AsAssignment represents a GTM asmap assignment structure

--- a/configgtm-v1_5/asmap_test.go
+++ b/configgtm-v1_5/asmap_test.go
@@ -1,0 +1,262 @@
+package configgtm
+
+import (
+	"testing"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/jsonhooks-v1"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
+)
+
+var (
+	config = edgegrid.Config{
+		Host:         "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/",
+		AccessToken:  "akab-access-token-xxx-xxxxxxxxxxxxxxxx",
+		ClientToken:  "akab-client-token-xxx-xxxxxxxxxxxxxxxx",
+		ClientSecret: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=",
+		MaxBody:      2048,
+		Debug:        false,
+	}
+)
+
+var GtmTestAsMap = "testAsMap"
+var gtmTestDomain = "gtmdomtest.akadns.net"
+
+func instantiateAsMap() *AsMap {
+
+	asMap := NewAsMap(GtmTestAsMap)
+	asMapData := []byte(`{
+                        "assignments": [ {
+                                        "asNumbers": [ 12222, 16702, 17334 ],
+                                        "datacenterId": 3134,
+                                        "nickname": "Frostfangs and the Fist of First Men"
+                                }, {
+                                        "asNumbers": [ 16625 ],
+                                        "datacenterId": 3133,
+                                        "nickname": "Winterfell"
+                                } ],
+                        "defaultDatacenter": {
+                                "datacenterId": 5400,
+                                "nickname": "All Other AS numbers"
+                        },
+                        "name": "testAsMap"
+              }`)
+	jsonhooks.Unmarshal(asMapData, asMap)
+
+	return asMap
+
+}
+
+// Verify GetAsMap. Name hardcoded. Should pass, e.g. no API errors and resource returned
+// Depends on CreateAsMap
+func TestGetAsMap(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/as-maps/" + GtmTestAsMap)
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/as-maps/"+GtmTestAsMap).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "assignments": [ {
+                                        "asNumbers": [ 12222, 16702, 17334 ],
+                                        "datacenterId": 3134,
+                                        "nickname": "Frostfangs and the Fist of First Men"
+                                }, {
+                                        "asNumbers": [ 16625 ],
+                                        "datacenterId": 3133,
+                                        "nickname": "Winterfell"
+                                } ],
+                        "defaultDatacenter": {
+                                "datacenterId": 5400,
+                                "nickname": "All Other AS numbers"
+                        },
+                        "links": [ {
+                                "href": "/config-gtm/v1/domains/example.akadns.net/as-maps/The%20North",
+                                "rel": "self"
+                        } ], 
+                        "name": "testAsMap"
+               }`)
+
+	Init(config)
+
+	testAsMap, err := GetAsMap(GtmTestAsMap, gtmTestDomain)
+	assert.NoError(t, err)
+	assert.IsType(t, &AsMap{}, testAsMap)
+	assert.Equal(t, GtmTestAsMap, testAsMap.Name)
+
+}
+
+// Verify failed case for GetAsMap. Should pass, e.g. no API errors and domain not found
+func TestGetBadAsMap(t *testing.T) {
+
+	badName := "somebadname"
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/as-maps/" + badName)
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/as-maps/"+badName).
+		HeaderPresent("Authorization").
+		Reply(404).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                }`)
+
+	Init(config)
+
+	_, err := GetAsMap(badName, gtmTestDomain)
+	assert.Error(t, err)
+
+}
+
+// Test Create AsMap.
+func TestCreateAsMap(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/as-maps/" + GtmTestAsMap)
+	mock.
+		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/as-maps/"+GtmTestAsMap).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                    "resource" : {
+                        "assignments": [ {
+                                        "asNumbers": [ 12222, 16702, 17334 ],
+                                        "datacenterId": 3134,
+                                        "nickname": "Frostfangs and the Fist of First Men"
+                                }, {
+                                        "asNumbers": [ 16625 ],
+                                        "datacenterId": 3133,
+                                        "nickname": "Winterfell"
+                                } ],
+                        "defaultDatacenter": {
+                                "datacenterId": 5400,
+                                "nickname": "All Other AS numbers"
+                        },
+                        "links": [ {
+                                "href": "/config-gtm/v1/domains/example.akadns.net/as-maps/The%20North",
+                                "rel": "self"
+                        } ],
+                        "name": "testAsMap"
+                    },
+                    "status" : {
+                           "changeId": "93a48b86-4fc3-4a5f-9ca2-036835034cc6",
+                           "links": [
+                               {
+                                  "href": "/config-gtm/v1/domains/example.akadns.net/status/current",
+                                  "rel": "self"
+                               }
+                           ],
+                           "message": "Change Pending",
+                           "passingValidation": true,
+                           "propagationStatus": "PENDING",
+                           "propagationStatusDate": "2014-04-15T11:30:27.000+0000"
+                    }
+               }`)
+
+	Init(config)
+
+	testAsMap := instantiateAsMap()
+	statresp, err := testAsMap.Create(gtmTestDomain)
+	assert.NoError(t, err)
+
+	assert.IsType(t, &AsMap{}, statresp.Resource)
+	assert.Equal(t, GtmTestAsMap, statresp.Resource.Name)
+
+}
+
+func TestUpdateAsMap(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/as-maps/" + GtmTestAsMap)
+	mock.
+		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/as-maps/"+GtmTestAsMap).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                    "resource" : {
+                        "assignments": [ {
+                                        "asNumbers": [ 12222, 16702, 17334 ],
+                                        "datacenterId": 3134,
+                                        "nickname": "Frostfangs and the Fist of First Men"
+                                }, {
+                                        "asNumbers": [ 16625 ],
+                                        "datacenterId": 3133,
+                                        "nickname": "Winterfell"
+                                } ],
+                        "defaultDatacenter": {
+                                "datacenterId": 5400,
+                                "nickname": "All Other AS numbers"
+                        },
+                        "links": [ {
+                                "href": "/config-gtm/v1/domains/example.akadns.net/as-maps/The%20North",
+                                "rel": "self"
+                        } ],
+                        "name": "testAsMap"
+                    },
+                    "status" : {
+                           "changeId": "93a48b86-4fc3-4a5f-9ca2-036835034cc6",
+                           "links": [
+                               {
+                                  "href": "/config-gtm/v1/domains/example.akadns.net/status/current",
+                                  "rel": "self"
+                               }
+                           ],
+                           "message": "Change Pending",
+                           "passingValidation": true,
+                           "propagationStatus": "PENDING",
+                           "propagationStatusDate": "2014-04-15T11:30:27.000+0000"
+                    }
+               }`)
+
+	Init(config)
+
+	testAsMap := instantiateAsMap()
+	_, err := testAsMap.Update(gtmTestDomain)
+	assert.NoError(t, err)
+
+}
+
+func TestDeleteAsMap(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/as-maps/" + GtmTestAsMap)
+	mock.
+		Delete("/config-gtm/v1/domains/"+gtmTestDomain+"/as-maps/"+GtmTestAsMap).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                    "resource" : {
+                    },
+                    "status" : {
+                           "changeId": "93a48b86-4fc3-4a5f-9ca2-036835034cc6",
+                           "links": [
+                               {
+                                  "href": "/config-gtm/v1/domains/example.akadns.net/status/current",
+                                  "rel": "self"
+                               }
+                           ],
+                           "message": "Change Pending",
+                           "passingValidation": true,
+                           "propagationStatus": "PENDING",
+                           "propagationStatusDate": "2014-04-15T11:30:27.000+0000"
+                    }
+               }`)
+
+	Init(config)
+
+	getAsMap := instantiateAsMap()
+	stat, err := getAsMap.Delete(gtmTestDomain)
+	assert.NoError(t, err)
+	assert.Equal(t, "93a48b86-4fc3-4a5f-9ca2-036835034cc6", stat.ChangeId)
+
+}

--- a/configgtm-v1_5/asmap_test.go
+++ b/configgtm-v1_5/asmap_test.go
@@ -59,7 +59,7 @@ func TestGetAsMap(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/as-maps/"+GtmTestAsMap).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "assignments": [ {
                                         "asNumbers": [ 12222, 16702, 17334 ],
@@ -101,7 +101,7 @@ func TestGetBadAsMap(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/as-maps/"+badName).
 		HeaderPresent("Authorization").
 		Reply(404).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                 }`)
 
@@ -122,7 +122,7 @@ func TestCreateAsMap(t *testing.T) {
 		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/as-maps/"+GtmTestAsMap).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                     "resource" : {
                         "assignments": [ {
@@ -179,7 +179,7 @@ func TestUpdateAsMap(t *testing.T) {
 		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/as-maps/"+GtmTestAsMap).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                     "resource" : {
                         "assignments": [ {
@@ -233,7 +233,7 @@ func TestDeleteAsMap(t *testing.T) {
 		Delete("/config-gtm/v1/domains/"+gtmTestDomain+"/as-maps/"+GtmTestAsMap).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                     "resource" : {
                     },

--- a/configgtm-v1_5/cidrmap.go
+++ b/configgtm-v1_5/cidrmap.go
@@ -1,0 +1,247 @@
+package configgtm
+
+import (
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
+
+	"fmt"
+)
+
+//
+// Handle Operations on gtm cidrmaps
+// Based on 1.4 schema
+//
+
+//CidrAssignment represents a GTM cidr assignment element
+type CidrAssignment struct {
+	DatacenterBase
+	Blocks []string `json:"blocks"`
+}
+
+// CidrMap  represents a GTM cidrMap element
+type CidrMap struct {
+	DefaultDatacenter *DatacenterBase   `json:"defaultDatacenter"`
+	Assignments       []*CidrAssignment `json:"assignments,omitempty"`
+	Name              string            `json:"name"`
+	Links             []*Link           `json:"links,omitempty"`
+}
+
+// CidrMapList represents a GTM returned cidrmap list body
+type CidrMapList struct {
+	CidrMapItems []*CidrMap `json:"items"`
+}
+
+// NewCidrMap creates a new CidrMap object
+func NewCidrMap(name string) *CidrMap {
+	cidrmap := &CidrMap{Name: name}
+	return cidrmap
+}
+
+// ListCidrMap retreieves all CidrMaps
+func ListCidrMaps(domainName string) ([]*CidrMap, error) {
+	cidrs := &CidrMapList{}
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/cidr-maps", domainName),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	printHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, CommonError{entityName: "cidrMap"}
+	}
+	err = client.BodyJSON(res, cidrs)
+	if err != nil {
+		return nil, err
+	}
+
+	return cidrs.CidrMapItems, nil
+
+}
+
+// GetCidrMap retrieves a CidrMap with the given name.
+func GetCidrMap(name, domainName string) (*CidrMap, error) {
+	cidr := NewCidrMap(name)
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/cidr-maps/%s", domainName, name),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	printHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, CommonError{entityName: "cidrMap", name: name}
+	} else {
+		err = client.BodyJSON(res, cidr)
+		if err != nil {
+			return nil, err
+		}
+
+		return cidr, nil
+	}
+}
+
+// Instantiate new Assignment struct
+func (cidr *CidrMap) NewAssignment(dcid int, nickname string) *CidrAssignment {
+	cidrAssign := &CidrAssignment{}
+	cidrAssign.DatacenterId = dcid
+	cidrAssign.Nickname = nickname
+
+	return cidrAssign
+}
+
+// Instantiate new Default Datacenter Struct
+func (cidr *CidrMap) NewDefaultDatacenter(dcid int) *DatacenterBase {
+	return &DatacenterBase{DatacenterId: dcid}
+}
+
+// Create CidrMap in provided domain
+func (cidr *CidrMap) Create(domainName string) (*CidrMapResponse, error) {
+
+	// Use common code. Any specific validation needed?
+
+	return cidr.save(domainName)
+
+}
+
+// Update CidrMap in given domain
+func (cidr *CidrMap) Update(domainName string) (*ResponseStatus, error) {
+
+	// common code
+
+	stat, err := cidr.save(domainName)
+	if err != nil {
+		return nil, err
+	}
+	return stat.Status, err
+
+}
+
+// Save CidrMap in given domain. Common path for Create and Update.
+func (cidr *CidrMap) save(domainName string) (*CidrMapResponse, error) {
+
+	req, err := client.NewJSONRequest(
+		Config,
+		"PUT",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/cidr-maps/%s", domainName, cidr.Name),
+		cidr,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+
+	// Network error
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "cidrMap",
+			name:             cidr.Name,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	printHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "cidrMap", name: cidr.Name, apiErrorMessage: err.Detail, err: err}
+	}
+
+	responseBody := &CidrMapResponse{}
+	// Unmarshall whole response body for updated entity and in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody, nil
+}
+
+// Delete CidrMap method
+func (cidr *CidrMap) Delete(domainName string) (*ResponseStatus, error) {
+
+	req, err := client.NewRequest(
+		Config,
+		"DELETE",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/cidr-maps/%s", domainName, cidr.Name),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	printHttpResponse(res, true)
+
+	// Network error
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "cidrMap",
+			name:             cidr.Name,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "cidrMap", name: cidr.Name, apiErrorMessage: err.Detail, err: err}
+	}
+
+	responseBody := &ResponseBody{}
+	// Unmarshall whole response body in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody.Status, nil
+
+}

--- a/configgtm-v1_5/cidrmap.go
+++ b/configgtm-v1_5/cidrmap.go
@@ -8,7 +8,7 @@ import (
 
 //
 // Handle Operations on gtm cidrmaps
-// Based on 1.4 schema
+// Based on 1.5 schema
 //
 
 //CidrAssignment represents a GTM cidr assignment element

--- a/configgtm-v1_5/cidrmap_test.go
+++ b/configgtm-v1_5/cidrmap_test.go
@@ -1,0 +1,301 @@
+package configgtm
+
+import (
+	"testing"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/jsonhooks-v1"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
+)
+
+var GtmTestCidrMap = "testCidrMap"
+
+func instantiateCidrMap() *CidrMap {
+
+	cidrMap := NewCidrMap(GtmTestCidrMap)
+	cidrMapData := []byte(`{
+                               "assignments": [ {
+                                       "blocks": [ "1.2.3.0/24" ],
+                                       "datacenterId": 3134,
+                                       "nickname": "Frostfangs and the Fist of First Men"
+                               },
+                               {
+                                       "blocks": [ "1.2.4.0/24" ],
+                                       "datacenterId": 3133,
+                                       "nickname": "Winterfell"
+                               } ],
+                               "defaultDatacenter": {
+                                       "datacenterId": 5400,
+                                       "nickname": "All Other CIDR Blocks"
+                               },
+                               "links": [ {
+                                       "href": "/config-gtm/v1/domains/example.akadns.net/cidr-maps/testCidrMap",
+                                       "rel": "self"
+                               } ],
+                               "name": "testCidrMap"
+              }`)
+	jsonhooks.Unmarshal(cidrMapData, cidrMap)
+
+	return cidrMap
+
+}
+
+// Verify ListCidrMap. Name hardcoded. Should pass, e.g. no API errors and resource returned
+func TestListCidrMaps(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/cidr-maps")
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/cidr-maps").
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "items" : [ {
+                               "assignments": [ {
+                                       "blocks": [ "1.2.3.0/24" ],
+                                       "datacenterId": 3134,
+                                       "nickname": "Frostfangs and the Fist of First Men"
+                               },
+                               {
+                                       "blocks": [ "1.2.4.0/24" ],
+                                       "datacenterId": 3133,
+                                       "nickname": "Winterfell"
+                               } ],
+                               "defaultDatacenter": {
+                                       "datacenterId": 5400,
+                                       "nickname": "All Other CIDR Blocks"
+                               },
+                               "links": [ {
+                                       "href": "/config-gtm/v1/domains/example.akadns.net/cidr-maps/testCidrMap",
+                                       "rel": "self"
+                               } ],
+                               "name": "testCidrMap"
+                       } ]
+               }`)
+
+	Init(config)
+
+	testCidrMap, err := ListCidrMaps(gtmTestDomain)
+	assert.NoError(t, err)
+	assert.IsType(t, &CidrMap{}, testCidrMap[0])
+	assert.Equal(t, GtmTestCidrMap, testCidrMap[0].Name)
+
+}
+
+// Verify GetCidrMap. Name hardcoded. Should pass, e.g. no API errors and resource returned
+func TestGetCidrMap(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/cidr-maps/" + GtmTestCidrMap)
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/cidr-maps/"+GtmTestCidrMap).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                               "assignments": [ {
+                                       "blocks": [ "1.2.3.0/24" ],
+                                       "datacenterId": 3134,
+                                       "nickname": "Frostfangs and the Fist of First Men"
+                               },
+                               {
+                                       "blocks": [ "1.2.4.0/24" ],
+                                       "datacenterId": 3133,
+                                       "nickname": "Winterfell"
+                               } ],
+                               "defaultDatacenter": {
+                                       "datacenterId": 5400,
+                                       "nickname": "All Other CIDR Blocks"
+                               },
+                               "links": [ {
+                                       "href": "/config-gtm/v1/domains/example.akadns.net/cidr-maps/testCidrMap",
+                                       "rel": "self"
+                               } ],
+                               "name": "testCidrMap"
+               }`)
+
+	Init(config)
+
+	testCidrMap, err := GetCidrMap(GtmTestCidrMap, gtmTestDomain)
+	assert.NoError(t, err)
+	assert.IsType(t, &CidrMap{}, testCidrMap)
+	assert.Equal(t, GtmTestCidrMap, testCidrMap.Name)
+
+}
+
+// Verify failed case for GetCidrMap. Should pass, e.g. no API errors and domain not found
+func TestGetBadCidrMap(t *testing.T) {
+
+	badName := "somebadname"
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/cidr-maps/" + badName)
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/cidr-maps/"+badName).
+		HeaderPresent("Authorization").
+		Reply(404).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                }`)
+
+	Init(config)
+
+	_, err := GetCidrMap(badName, gtmTestDomain)
+	assert.Error(t, err)
+
+}
+
+// Test Create CidrMap.
+func TestCreateCidrMap(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/cidr-maps/" + GtmTestCidrMap)
+	mock.
+		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/cidr-maps/"+GtmTestCidrMap).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                    "resource" : {
+                               "assignments": [ {
+                                       "blocks": [ "1.2.3.0/24" ],
+                                       "datacenterId": 3134,
+                                       "nickname": "Frostfangs and the Fist of First Men"
+                               },
+                               {
+                                       "blocks": [ "1.2.4.0/24" ],
+                                       "datacenterId": 3133,
+                                       "nickname": "Winterfell"
+                               } ],
+                               "defaultDatacenter": {
+                                       "datacenterId": 5400,
+                                       "nickname": "All Other CIDR Blocks"
+                               },
+                               "links": [ {
+                                       "href": "/config-gtm/v1/domains/example.akadns.net/cidr-maps/testCidrMap",
+                                       "rel": "self"
+                               } ],
+                               "name": "testCidrMap"
+                    },
+                    "status" : {
+                           "changeId": "93a48b86-4fc3-4a5f-9ca2-036835034cc6",
+                           "links": [
+                               {
+                                  "href": "/config-gtm/v1/domains/example.akadns.net/status/current",
+                                  "rel": "self"
+                               }
+                           ],
+                           "message": "Change Pending",
+                           "passingValidation": true,
+                           "propagationStatus": "PENDING",
+                           "propagationStatusDate": "2014-04-15T11:30:27.000+0000"
+                    }
+               }`)
+
+	Init(config)
+
+	testCidrMap := instantiateCidrMap()
+	statresp, err := testCidrMap.Create(gtmTestDomain)
+	assert.NoError(t, err)
+
+	assert.IsType(t, &CidrMap{}, statresp.Resource)
+	assert.Equal(t, GtmTestCidrMap, statresp.Resource.Name)
+
+}
+
+func TestUpdateCidrMap(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/cidr-maps/" + GtmTestCidrMap)
+	mock.
+		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/cidr-maps/"+GtmTestCidrMap).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                    "resource" : {
+                               "assignments": [ {
+                                       "blocks": [ "1.2.3.0/24" ],
+                                       "datacenterId": 3134,
+                                       "nickname": "Frostfangs and the Fist of First Men"
+                               },
+                               {
+                                       "blocks": [ "1.2.4.0/24" ],
+                                       "datacenterId": 3133,
+                                       "nickname": "Winterfell"
+                               } ],
+                               "defaultDatacenter": {
+                                       "datacenterId": 5400,
+                                       "nickname": "All Other CIDR Blocks"
+                               },
+                               "links": [ {
+                                       "href": "/config-gtm/v1/domains/example.akadns.net/cidr-maps/testCidrMap",
+                                       "rel": "self"
+                               } ],
+                               "name": "testCidrMap"
+                    },
+                    "status" : {
+                           "changeId": "93a48b86-4fc3-4a5f-9ca2-036835034cc6",
+                           "links": [
+                               {
+                                  "href": "/config-gtm/v1/domains/example.akadns.net/status/current",
+                                  "rel": "self"
+                               }
+                           ],
+                           "message": "Change Pending",
+                           "passingValidation": true,
+                           "propagationStatus": "PENDING",
+                           "propagationStatusDate": "2014-04-15T11:30:27.000+0000"
+                    }
+               }`)
+
+	Init(config)
+
+	testCidrMap := instantiateCidrMap()
+	_, err := testCidrMap.Update(gtmTestDomain)
+	assert.NoError(t, err)
+
+}
+
+func TestDeleteCidrMap(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/cidr-maps/" + GtmTestCidrMap)
+	mock.
+		Delete("/config-gtm/v1/domains/"+gtmTestDomain+"/cidr-maps/"+GtmTestCidrMap).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                    "resource" : {
+                    },
+                    "status" : {
+                           "changeId": "93a48b86-4fc3-4a5f-9ca2-036835034cc6",
+                           "links": [
+                               {
+                                  "href": "/config-gtm/v1/domains/example.akadns.net/status/current",
+                                  "rel": "self"
+                               }
+                           ],
+                           "message": "Change Pending",
+                           "passingValidation": true,
+                           "propagationStatus": "PENDING",
+                           "propagationStatusDate": "2014-04-15T11:30:27.000+0000"
+                    }
+               }`)
+
+	Init(config)
+
+	getCidrMap := instantiateCidrMap()
+	stat, err := getCidrMap.Delete(gtmTestDomain)
+	assert.NoError(t, err)
+	assert.Equal(t, "93a48b86-4fc3-4a5f-9ca2-036835034cc6", stat.ChangeId)
+
+}

--- a/configgtm-v1_5/cidrmap_test.go
+++ b/configgtm-v1_5/cidrmap_test.go
@@ -51,7 +51,7 @@ func TestListCidrMaps(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/cidr-maps").
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "items" : [ {
                                "assignments": [ {
@@ -95,7 +95,7 @@ func TestGetCidrMap(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/cidr-maps/"+GtmTestCidrMap).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                                "assignments": [ {
                                        "blocks": [ "1.2.3.0/24" ],
@@ -138,7 +138,7 @@ func TestGetBadCidrMap(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/cidr-maps/"+badName).
 		HeaderPresent("Authorization").
 		Reply(404).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                 }`)
 
@@ -159,7 +159,7 @@ func TestCreateCidrMap(t *testing.T) {
 		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/cidr-maps/"+GtmTestCidrMap).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                     "resource" : {
                                "assignments": [ {
@@ -217,7 +217,7 @@ func TestUpdateCidrMap(t *testing.T) {
 		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/cidr-maps/"+GtmTestCidrMap).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                     "resource" : {
                                "assignments": [ {
@@ -272,7 +272,7 @@ func TestDeleteCidrMap(t *testing.T) {
 		Delete("/config-gtm/v1/domains/"+gtmTestDomain+"/cidr-maps/"+GtmTestCidrMap).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                     "resource" : {
                     },

--- a/configgtm-v1_5/common.go
+++ b/configgtm-v1_5/common.go
@@ -1,0 +1,129 @@
+package configgtm
+
+import (
+	"fmt"
+	"net/http"
+)
+
+//
+// Common data types and methods
+// Based on 1.3 schemas
+//
+
+// Append url args to req
+func appendReqArgs(req *http.Request, queryArgs map[string]string) {
+
+	// Look for optional args
+	if len(queryArgs) > 0 {
+		q := req.URL.Query()
+		for argName, argVal := range queryArgs {
+			q.Add(argName, argVal)
+		}
+		req.URL.RawQuery = q.Encode()
+	}
+
+}
+
+// default schema version
+// TODO: retrieve from environment or elsewhere in Service Init
+var schemaVersion string = "1.4"
+
+// internal method to set version. passed in as string
+func setVersionHeader(req *http.Request, version string) {
+
+	req.Header.Set("Accept", fmt.Sprintf("application/vnd.config-gtm.v%s+json", version))
+
+	if req.Method != "GET" {
+		req.Header.Set("Content-Type", fmt.Sprintf("application/vnd.config-gtm.v%s+json", version))
+	}
+
+	return
+
+}
+
+// response Status is returned on Create, Update or Delete operations for all entity types
+type ResponseStatus struct {
+	ChangeId              string  `json:"changeId,omitempty"`
+	Links                 *[]Link `json:"links,omitempty"`
+	Message               string  `json:"message,omitempty"`
+	PassingValidation     bool    `json:"passingValidation,omitempty"`
+	PropagationStatus     string  `json:"propagationStatus,omitempty"`
+	PropagationStatusDate string  `json:"propagationStatusDate,omitempty"`
+}
+
+// NewResponseStatus returns a new ResponseStatus struct
+func NewResponseStatus() *ResponseStatus {
+
+	return &ResponseStatus{}
+
+}
+
+// Generic response structs
+type ResponseBody struct {
+	Resource interface{}     `json:"resource"`
+	Status   *ResponseStatus `json:"status"`
+}
+
+// Response structs by Entity Type
+type DomainResponse struct {
+	Resource *Domain         `json:"resource"`
+	Status   *ResponseStatus `json:"status"`
+}
+
+type DatacenterResponse struct {
+	Status   *ResponseStatus `json:"status"`
+	Resource *Datacenter     `json:"resource"`
+}
+
+type PropertyResponse struct {
+	Resource *Property       `json:"resource"`
+	Status   *ResponseStatus `json:"status"`
+}
+
+type ResourceResponse struct {
+	Resource *Resource       `json:"resource"`
+	Status   *ResponseStatus `json:"status"`
+}
+
+type CidrMapResponse struct {
+	Resource *CidrMap        `json:"resource"`
+	Status   *ResponseStatus `json:"status"`
+}
+
+type GeoMapResponse struct {
+	Resource *GeoMap         `json:"resource"`
+	Status   *ResponseStatus `json:"status"`
+}
+
+type AsMapResponse struct {
+	Resource *AsMap          `json:"resource"`
+	Status   *ResponseStatus `json:"status"`
+}
+
+// Probably THE most common type
+type Link struct {
+	Rel  string `json:"rel"`
+	Href string `json:"href"`
+}
+
+//
+type LoadObject struct {
+	LoadObject     string   `json:"loadObject,omitempty"`
+	LoadObjectPort int      `json:"loadObjectPort,omitempty"`
+	LoadServers    []string `json:"loadServers,omitempty"`
+}
+
+// NewLoadObject returns a new LoadObject structure
+func NewLoadObject() *LoadObject {
+	return &LoadObject{}
+}
+
+type DatacenterBase struct {
+	Nickname     string `json:"nickname,omitempty"`
+	DatacenterId int    `json:"datacenterId"`
+}
+
+// NewDatacenterBase returns a new DatacenterBase structure
+func NewDatacenterBase() *DatacenterBase {
+	return &DatacenterBase{}
+}

--- a/configgtm-v1_5/common.go
+++ b/configgtm-v1_5/common.go
@@ -7,7 +7,7 @@ import (
 
 //
 // Common data types and methods
-// Based on 1.3 schemas
+// Based on 1.5 schemas
 //
 
 // Append url args to req

--- a/configgtm-v1_5/datacenter.go
+++ b/configgtm-v1_5/datacenter.go
@@ -1,0 +1,363 @@
+package configgtm
+
+import (
+	"errors"
+	"fmt"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
+	"strconv"
+	"strings"
+)
+
+//
+// Handle Operations on gtm datacenters
+// Based on 1.4 schema
+//
+
+// Datacenter represents a GTM datacenter
+type Datacenter struct {
+	City                          string      `json:"city,omitempty"`
+	CloneOf                       int         `json:"cloneOf,omitempty"`
+	CloudServerHostHeaderOverride bool        `json:"cloudServerHostHeaderOverride"`
+	CloudServerTargeting          bool        `json:"cloudServerTargeting"`
+	Continent                     string      `json:"continent,omitempty"`
+	Country                       string      `json:"country,omitempty"`
+	DefaultLoadObject             *LoadObject `json:"defaultLoadObject,omitempty"`
+	Latitude                      float64     `json:"latitude,omitempty"`
+	Links                         []*Link     `json:"links,omitempty"`
+	Longitude                     float64     `json:"longitude,omitempty"`
+	Nickname                      string      `json:"nickname,omitempty"`
+	PingInterval                  int         `json:"pingInterval,omitempty"`
+	PingPacketSize                int         `json:"pingPacketSize,omitempty"`
+	DatacenterId                  int         `json:"datacenterId,omitempty"`
+	ScorePenalty                  int         `json:"scorePenalty,omitempty"`
+	ServermonitorLivenessCount    int         `json:"servermonitorLivenessCount,omitempty"`
+	ServermonitorLoadCount        int         `json:"servermonitorLoadCount,omitempty"`
+	ServermonitorPool             string      `json:"servermonitorPool,omitempty"`
+	StateOrProvince               string      `json:"stateOrProvince,omitempty"`
+	Virtual                       bool        `json:"virtual"`
+}
+
+type DatacenterList struct {
+	DatacenterItems []*Datacenter `json:"items"`
+}
+
+// NewDatacenterResponse instantiates a new DatacenterResponse structure
+func NewDatacenterResponse() *DatacenterResponse {
+	dcResp := &DatacenterResponse{}
+	return dcResp
+}
+
+// NewDatacenter creates a new Datacenter object
+func NewDatacenter() *Datacenter {
+	dc := &Datacenter{}
+	return dc
+}
+
+// ListDatacenters retreieves all Datacenters
+func ListDatacenters(domainName string) ([]*Datacenter, error) {
+	dcs := &DatacenterList{}
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/datacenters", domainName),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	printHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, CommonError{entityName: "Datacenter"}
+	} else {
+		err = client.BodyJSON(res, dcs)
+		if err != nil {
+			return nil, err
+		}
+
+		return dcs.DatacenterItems, nil
+	}
+}
+
+// GetDatacenter retrieves a Datacenter with the given name. NOTE: Id arg is int!
+func GetDatacenter(dcID int, domainName string) (*Datacenter, error) {
+
+	dc := NewDatacenter()
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/datacenters/%s", domainName, strconv.Itoa(dcID)),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	printHttpRequest(req, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, CommonError{entityName: "Datacenter", name: strconv.Itoa(dcID)}
+	} else {
+		err = client.BodyJSON(res, dc)
+		if err != nil {
+			return nil, err
+		}
+
+		return dc, nil
+	}
+}
+
+// Create the datacenter identified by the receiver argument in the specified domain.
+func (dc *Datacenter) Create(domainName string) (*DatacenterResponse, error) {
+
+	req, err := client.NewJSONRequest(
+		Config,
+		"POST",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/datacenters", domainName),
+		dc,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+
+	// Network
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "Domain",
+			name:             domainName,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	printHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "Domain", name: domainName, apiErrorMessage: err.Detail, err: err}
+	}
+
+	responseBody := NewDatacenterResponse()
+	// Unmarshall whole response body for updated DC and in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody, nil
+
+}
+
+var MapDefaultDC int = 5400
+var Ipv4DefaultDC int = 5401
+var Ipv6DefaultDC int = 5402
+
+// Create Default Datacenter for Maps
+func CreateMapsDefaultDatacenter(domainName string) (*Datacenter, error) {
+
+	return createDefaultDC(MapDefaultDC, domainName)
+
+}
+
+// Create Default Datacenter for IPv4 Selector
+func CreateIPv4DefaultDatacenter(domainName string) (*Datacenter, error) {
+
+	return createDefaultDC(Ipv4DefaultDC, domainName)
+
+}
+
+// Create Default Datacenter for IPv6 Selector
+func CreateIPv6DefaultDatacenter(domainName string) (*Datacenter, error) {
+
+	return createDefaultDC(Ipv6DefaultDC, domainName)
+
+}
+
+// Worker function to create Default Datacenter identified id in the specified domain.
+func createDefaultDC(defaultID int, domainName string) (*Datacenter, error) {
+
+	if defaultID != MapDefaultDC && defaultID != Ipv4DefaultDC && defaultID != Ipv6DefaultDC {
+		return nil, errors.New("Invalid default datacenter id provided for creation")
+	}
+	// check if already exists
+	dc, err := GetDatacenter(defaultID, domainName)
+	if err == nil {
+		return dc, err
+	} else {
+		if !strings.Contains(err.Error(), "not found") || !strings.Contains(err.Error(), "Datacenter") {
+			return nil, err
+		}
+	}
+	defaultURL := fmt.Sprintf("/config-gtm/v1/domains/%s/datacenters/", domainName)
+	switch defaultID {
+	case MapDefaultDC:
+		defaultURL += "default-datacenter-for-maps"
+	case Ipv4DefaultDC:
+		defaultURL += "datacenter-for-ip-version-selector-ipv4"
+	case Ipv6DefaultDC:
+		defaultURL += "datacenter-for-ip-version-selector-ipv6"
+	}
+	req, err := client.NewJSONRequest(
+		Config,
+		"POST",
+		defaultURL,
+		"",
+	)
+	if err != nil {
+		return nil, err
+	}
+	setVersionHeader(req, schemaVersion)
+	printHttpRequest(req, true)
+	res, err := client.Do(Config, req)
+	// Network
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "Domain",
+			name:             domainName,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+	printHttpResponse(res, true)
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "Domain", name: domainName, apiErrorMessage: err.Detail, err: err}
+	}
+	responseBody := NewDatacenterResponse()
+	// Unmarshall whole response body for updated DC and in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody.Resource, nil
+
+}
+
+// Update the datacenter identified in the receiver argument in the provided domain.
+func (dc *Datacenter) Update(domainName string) (*ResponseStatus, error) {
+
+	req, err := client.NewJSONRequest(
+		Config,
+		"PUT",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/datacenters/%s", domainName, strconv.Itoa(dc.DatacenterId)),
+		dc,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+
+	// Network error
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "Datacenter",
+			name:             strconv.Itoa(dc.DatacenterId),
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	printHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "Datacenter", name: strconv.Itoa(dc.DatacenterId), apiErrorMessage: err.Detail, err: err}
+	}
+
+	responseBody := NewDatacenterResponse()
+	// Unmarshall whole response body for updated entity and in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody.Status, nil
+}
+
+// Delete the datacenter identified by the receiver argument from the domain specified.
+func (dc *Datacenter) Delete(domainName string) (*ResponseStatus, error) {
+
+	req, err := client.NewRequest(
+		Config,
+		"DELETE",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/datacenters/%s", domainName, strconv.Itoa(dc.DatacenterId)),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Network error
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "Datacenter",
+			name:             strconv.Itoa(dc.DatacenterId),
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	printHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "Datacenter", name: strconv.Itoa(dc.DatacenterId), apiErrorMessage: err.Detail, err: err}
+	}
+
+	responseBody := NewDatacenterResponse()
+	// Unmarshall whole response body in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody.Status, nil
+}

--- a/configgtm-v1_5/datacenter.go
+++ b/configgtm-v1_5/datacenter.go
@@ -3,14 +3,15 @@ package configgtm
 import (
 	"errors"
 	"fmt"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
 	"strconv"
 	"strings"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
 )
 
 //
 // Handle Operations on gtm datacenters
-// Based on 1.4 schema
+// Based on 1.5 schema
 //
 
 // Datacenter represents a GTM datacenter

--- a/configgtm-v1_5/datacenter_test.go
+++ b/configgtm-v1_5/datacenter_test.go
@@ -1,0 +1,381 @@
+package configgtm
+
+import (
+	"testing"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/jsonhooks-v1"
+	//edge "github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
+
+	"fmt"
+)
+
+var GtmTestDC1 = "testDC1"
+var GtmTestDC2 = "testDC2"
+var dcMap = map[string]string{"GtmTestDC1": GtmTestDC1, "GtmTestDC2": GtmTestDC2}
+
+func instantiateDatacenter() *Datacenter {
+
+	dc := NewDatacenter()
+	dcData := []byte(`{
+                                "datacenterId" : 3131,
+                                "nickname" : "testDC1",
+                                "scorePenalty" : 0,
+                                "city" : null,
+                                "stateOrProvince" : null,
+                                "country" : null,
+                                "latitude" : null,
+                                "longitude" : null,
+                                "cloneOf" : null,
+                                "virtual" : true,
+                                "defaultLoadObject" : null,
+                                "continent" : null,
+                                "servermonitorPool" : null,
+                                "servermonitorLivenessCount" : null,
+                                "servermonitorLoadCount" : null,
+                                "pingInterval" : null,
+                                "pingPacketSize" : null,
+                                "cloudServerTargeting" : false,
+                                "cloudServerHostHeaderOverride" : false
+                       }`)
+	jsonhooks.Unmarshal(dcData, dc)
+
+	return dc
+
+}
+
+// Verify ListDatacenters. Should pass, e.g. no API errors and non nil list.
+func TestListDatacenters(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/datacenters")
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters").
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "items" : [ {
+                                "datacenterId" : 3131,
+                                "nickname" : "testDC1",
+                                "scorePenalty" : 0,
+                                "city" : null,                            
+                                "stateOrProvince" : null,
+                                "country" : null,
+                                "latitude" : null,
+                                "longitude" : null,
+                                "cloneOf" : null,
+                                "virtual" : true,
+                                "defaultLoadObject" : null,
+                                "continent" : null,
+                                "servermonitorPool" : null,
+                                "servermonitorLivenessCount" : null,
+                                "servermonitorLoadCount" : null,
+                                "pingInterval" : null,
+                                "pingPacketSize" : null,
+                                "cloudServerTargeting" : false,
+                                "cloudServerHostHeaderOverride" : false,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/datacenters/3131"
+                                } ]
+                        } ]
+                }`)
+
+	Init(config)
+
+	dcList, err := ListDatacenters(gtmTestDomain)
+	assert.NoError(t, err)
+	assert.NotEqual(t, dcList, nil)
+
+	if len(dcList) > 0 {
+		firstDC := dcList[0]
+		assert.Equal(t, firstDC.Nickname, GtmTestDC1)
+	} else {
+		assert.Equal(t, 0, 1, "ListDatacenters: empty list")
+		fmt.Println("ListDatacenters: empty list")
+	}
+
+}
+
+// Verify GetDatacenter. Name hardcoded. Should pass, e.g. no API errors and property returned
+// Depends on CreateDatacenter
+func TestGetDatacenter(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/datacenters/3131")
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters/3131").
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                                "datacenterId" : 3131,
+                                "nickname" : "testDC1",
+                                "scorePenalty" : 0,
+                                "city" : null,
+                                "stateOrProvince" : null,
+                                "country" : null,
+                                "latitude" : null,
+                                "longitude" : null,
+                                "cloneOf" : null,
+                                "virtual" : true,
+                                "defaultLoadObject" : null,
+                                "continent" : null,
+                                "servermonitorPool" : null,
+                                "servermonitorLivenessCount" : null,
+                                "servermonitorLoadCount" : null,
+                                "pingInterval" : null,
+                                "pingPacketSize" : null,
+                                "cloudServerTargeting" : false,
+                                "cloudServerHostHeaderOverride" : false,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/datacenters/3131"
+                                } ]
+              }`)
+
+	Init(config)
+
+	testDC, err := GetDatacenter(3131, gtmTestDomain)
+	assert.NoError(t, err)
+	assert.Equal(t, 3131, testDC.DatacenterId)
+
+}
+
+// Verify failed case for GetDatacenter. Should pass, e.g. no API errors and domain not found
+func TestGetBadDatacenter(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/datacenters/9999")
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters/9999").
+		HeaderPresent("Authorization").
+		Reply(404).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                }`)
+
+	Init(config)
+
+	_, err := GetDatacenter(9999, gtmTestDomain)
+	assert.Error(t, err)
+
+}
+
+// Test Create datacenter.
+func TestCreateDatacenter(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/datacenters")
+	mock.
+		Post("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters").
+		HeaderPresent("Authorization").
+		Reply(201).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "resource" : {
+                                "datacenterId" : 3131,
+                                "nickname" : "testDC1",
+                                "scorePenalty" : 0,
+                                "city" : null,
+                                "stateOrProvince" : null,
+                                "country" : null,
+                                "latitude" : null,
+                                "longitude" : null,
+                                "cloneOf" : null,
+                                "virtual" : true,
+                                "defaultLoadObject" : null,
+                                "continent" : null,
+                                "servermonitorPool" : null,
+                                "servermonitorLivenessCount" : null,
+                                "servermonitorLoadCount" : null,
+                                "pingInterval" : null,
+                                "pingPacketSize" : null,
+                                "cloudServerTargeting" : false,
+                                "cloudServerHostHeaderOverride" : false,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/datacenters/3131"
+                                } ]
+                        },
+                        "status" : {
+                                "message" : "Change Pending",
+                                "changeId" : "4c7e6466-84e1-4895-bdf5-e3608d708d69",
+                                "propagationStatus" : "PENDING",
+                                "propagationStatusDate" : "2019-05-30T17:47:02.831+00:00",
+                                "passingValidation" : true,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current"
+                                } ]
+                        }
+                }`)
+
+	testDC := NewDatacenter()
+	testDC.Nickname = GtmTestDC1
+	statresp, err := testDC.Create(gtmTestDomain)
+	assert.NoError(t, err)
+	assert.Equal(t, GtmTestDC1, statresp.Resource.Nickname)
+
+}
+
+func TestUpdateDatacenter(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/datacenters/3131")
+	mock.
+		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters/3131").
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "resource" : {
+                                "datacenterId" : 3131,
+                                "nickname" : "testDC1",
+                                "scorePenalty" : 0,
+                                "city" : null,
+                                "stateOrProvince" : null,
+                                "country" : null,
+                                "latitude" : null,
+                                "longitude" : null,
+                                "cloneOf" : null,
+                                "virtual" : true,
+                                "defaultLoadObject" : null,
+                                "continent" : null,
+                                "servermonitorPool" : null,
+                                "servermonitorLivenessCount" : null,
+                                "servermonitorLoadCount" : null,
+                                "pingInterval" : null,
+                                "pingPacketSize" : null,
+                                "cloudServerTargeting" : false,
+                                "cloudServerHostHeaderOverride" : false,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/datacenters/3131"
+                                } ]
+                        },
+                        "status" : {
+                                "message" : "Change Pending",
+                                "changeId" : "4c7e6466-84e1-4895-bdf5-e3608d708d69",
+                                "propagationStatus" : "PENDING",
+                                "propagationStatusDate" : "2019-05-30T17:47:02.831+00:00",
+                                "passingValidation" : true,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current"
+                                } ]
+                        }
+               }`)
+
+	Init(config)
+
+	testDC := instantiateDatacenter()
+	stat, err := testDC.Update(gtmTestDomain)
+	assert.NoError(t, err)
+	assert.Equal(t, stat.ChangeId, "4c7e6466-84e1-4895-bdf5-e3608d708d69")
+
+}
+
+func TestDeleteDatacenter(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/datacenters/3131")
+	mock.
+		Delete("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters/3131").
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "resource" : {
+                        },
+                        "status" : {
+                                "message" : "Change Pending",
+                                "changeId" : "4c7e6466-84e1-4895-bdf5-e3608d708d69",
+                                "propagationStatus" : "PENDING",
+                                "propagationStatusDate" : "2019-05-30T17:47:02.831+00:00",
+                                "passingValidation" : true,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current"
+                                } ]
+                        }
+                }`)
+
+	Init(config)
+
+	testDC := instantiateDatacenter()
+	_, err := testDC.Delete(gtmTestDomain)
+	assert.NoError(t, err)
+
+}
+
+func TestCreateMapsDefaultDatacenter(t *testing.T) {
+
+	defer gock.Off()
+
+	mock1 := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/datacenters/5400")
+	mock1.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters/5400").
+		HeaderPresent("Authorization").
+		Reply(404).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8")
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/datacenters/default-datacenter-for-maps")
+	mock.
+		Post("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters/default-datacenter-for-maps").
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "resource" : {
+                                "datacenterId" : 5400,
+                                "nickname" : "Default Datacenter",
+                                "scorePenalty" : 0,
+                                "city" : null,
+                                "stateOrProvince" : null,
+                                "country" : null,
+                                "latitude" : null,
+                                "longitude" : null,
+                                "cloneOf" : null,
+                                "virtual" : true,
+                                "defaultLoadObject" : null,
+                                "continent" : null,
+                                "servermonitorPool" : null,
+                                "servermonitorLivenessCount" : null,
+                                "servermonitorLoadCount" : null,
+                                "pingInterval" : null,
+                                "pingPacketSize" : null,
+                                "cloudServerTargeting" : false,
+                                "cloudServerHostHeaderOverride" : false,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/datacenters/5400"
+                                } ]
+                        },
+                        "status" : {
+                                "message" : "Change Pending",
+                                "changeId" : "4c7e6466-84e1-4895-bdf5-e3608d708d69",
+                                "propagationStatus" : "PENDING",
+                                "propagationStatusDate" : "2019-05-30T17:47:02.831+00:00",
+                                "passingValidation" : true,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current"
+                                } ]
+                        }
+                }`)
+
+	Init(config)
+	defDC, err := CreateMapsDefaultDatacenter(gtmTestDomain)
+	assert.NoError(t, err)
+	assert.Equal(t, defDC.DatacenterId, 5400)
+
+}

--- a/configgtm-v1_5/datacenter_test.go
+++ b/configgtm-v1_5/datacenter_test.go
@@ -55,7 +55,7 @@ func TestListDatacenters(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters").
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "items" : [ {
                                 "datacenterId" : 3131,
@@ -111,7 +111,7 @@ func TestGetDatacenter(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters/3131").
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                                 "datacenterId" : 3131,
                                 "nickname" : "testDC1",
@@ -156,7 +156,7 @@ func TestGetBadDatacenter(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters/9999").
 		HeaderPresent("Authorization").
 		Reply(404).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                 }`)
 
@@ -177,7 +177,7 @@ func TestCreateDatacenter(t *testing.T) {
 		Post("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters").
 		HeaderPresent("Authorization").
 		Reply(201).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "resource" : {
                                 "datacenterId" : 3131,
@@ -234,7 +234,7 @@ func TestUpdateDatacenter(t *testing.T) {
 		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters/3131").
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "resource" : {
                                 "datacenterId" : 3131,
@@ -292,7 +292,7 @@ func TestDeleteDatacenter(t *testing.T) {
 		Delete("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters/3131").
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "resource" : {
                         },
@@ -326,14 +326,14 @@ func TestCreateMapsDefaultDatacenter(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters/5400").
 		HeaderPresent("Authorization").
 		Reply(404).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8")
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8")
 
 	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/datacenters/default-datacenter-for-maps")
 	mock.
 		Post("/config-gtm/v1/domains/"+gtmTestDomain+"/datacenters/default-datacenter-for-maps").
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "resource" : {
                                 "datacenterId" : 5400,

--- a/configgtm-v1_5/domain.go
+++ b/configgtm-v1_5/domain.go
@@ -1,0 +1,486 @@
+package configgtm
+
+import (
+	"fmt"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
+	"net/http"
+	"reflect"
+	"strings"
+	"unicode"
+)
+
+//
+// Support gtm domains thru Edgegrid
+// Based on 1.4 Schema
+//
+
+// The Domain data structure represents a GTM domain
+type Domain struct {
+	Name                         string          `json:"name"`
+	Type                         string          `json:"type"`
+	AsMaps                       []*AsMap        `json:"asMaps,omitempty"`
+	Resources                    []*Resource     `json:"resources,omitempty"`
+	DefaultUnreachableThreshold  float32         `json:"defaultUnreachableThreshold,omitempty"`
+	EmailNotificationList        []string        `json:"emailNotificationList,omitempty"`
+	MinPingableRegionFraction    float32         `json:"minPingableRegionFraction,omitempty"`
+	DefaultTimeoutPenalty        int             `json:"defaultTimeoutPenalty,omitempty"`
+	Datacenters                  []*Datacenter   `json:"datacenters,omitempty"`
+	ServermonitorLivenessCount   int             `json:"servermonitorLivenessCount,omitempty"`
+	RoundRobinPrefix             string          `json:"roundRobinPrefix,omitempty"`
+	ServermonitorLoadCount       int             `json:"servermonitorLoadCount,omitempty"`
+	PingInterval                 int             `json:"pingInterval,omitempty"`
+	MaxTTL                       int64           `json:"maxTTL,omitempty"`
+	LoadImbalancePercentage      float64         `json:"loadImbalancePercentage,omitempty"`
+	DefaultHealthMax             float64         `json:"defaultHealthMax,omitempty"`
+	LastModified                 string          `json:"lastModified,omitempty"`
+	Status                       *ResponseStatus `json:"status,omitempty"`
+	MapUpdateInterval            int             `json:"mapUpdateInterval,omitempty"`
+	MaxProperties                int             `json:"maxProperties,omitempty"`
+	MaxResources                 int             `json:"maxResources,omitempty"`
+	DefaultSslClientPrivateKey   string          `json:"defaultSslClientPrivateKey,omitempty"`
+	DefaultErrorPenalty          int             `json:"defaultErrorPenalty,omitempty"`
+	Links                        []*Link         `json:"links,omitempty"`
+	Properties                   []*Property     `json:"properties,omitempty"`
+	MaxTestTimeout               float64         `json:"maxTestTimeout,omitempty"`
+	CnameCoalescingEnabled       bool            `json:"cnameCoalescingEnabled"`
+	DefaultHealthMultiplier      float64         `json:"defaultHealthMultiplier,omitempty"`
+	ServermonitorPool            string          `json:"servermonitorPool,omitempty"`
+	LoadFeedback                 bool            `json:"loadFeedback"`
+	MinTTL                       int64           `json:"minTTL,omitempty"`
+	GeographicMaps               []*GeoMap       `json:"geographicMaps,omitempty"`
+	CidrMaps                     []*CidrMap      `json:"cidrMaps,omitempty"`
+	DefaultMaxUnreachablePenalty int             `json:"defaultMaxUnreachablePenalty"`
+	DefaultHealthThreshold       float64         `json:"defaultHealthThreshold,omitempty"`
+	LastModifiedBy               string          `json:"lastModifiedBy,omitempty"`
+	ModificationComments         string          `json:"modificationComments,omitempty"`
+	MinTestInterval              int             `json:"minTestInterval,omitempty"`
+	PingPacketSize               int             `json:"pingPacketSize,omitempty"`
+	DefaultSslClientCertificate  string          `json:"defaultSslClientCertificate,omitempty"`
+	EndUserMappingEnabled        bool            `json:"endUserMappingEnabled"`
+}
+
+type DomainsList struct {
+	DomainItems []*DomainItem `json:"items"`
+}
+
+// DomainItem is a DomainsList item
+type DomainItem struct {
+	AcgId        string  `json:"acgId"`
+	LastModified string  `json:"lastModified"`
+	Links        []*Link `json:"links"`
+	Name         string  `json:"name"`
+	Status       string  `json:"status"`
+}
+
+// NewDomain is a utility function that creates a new Domain object.
+func NewDomain(domainName, domainType string) *Domain {
+	domain := &Domain{}
+	domain.Name = domainName
+	domain.Type = domainType
+	return domain
+}
+
+// GetStatus retrieves current status for the given domainname.
+func GetDomainStatus(domainName string) (*ResponseStatus, error) {
+	stat := &ResponseStatus{}
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/status/current", domainName),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	printHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, CommonError{entityName: "Domain", name: domainName}
+	} else {
+		err = client.BodyJSON(res, stat)
+		if err != nil {
+			return nil, err
+		}
+
+		return stat, nil
+	}
+}
+
+// ListDomains retrieves all Domains.
+func ListDomains() ([]*DomainItem, error) {
+	domains := &DomainsList{}
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		"/config-gtm/v1/domains/",
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	printHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, CommonError{entityName: "Domain"}
+	} else {
+		err = client.BodyJSON(res, domains)
+		if err != nil {
+			return nil, err
+		}
+
+		return domains.DomainItems, nil
+	}
+}
+
+// GetDomain retrieves a Domain with the given domainname.
+func GetDomain(domainName string) (*Domain, error) {
+	domain := NewDomain(domainName, "basic")
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-gtm/v1/domains/%s", domainName),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	printHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, CommonError{entityName: "Domain", name: domainName}
+	} else {
+		err = client.BodyJSON(res, domain)
+		if err != nil {
+			return nil, err
+		}
+
+		return domain, nil
+	}
+}
+
+// Save method; Create or Update
+func (domain *Domain) save(queryArgs map[string]string, req *http.Request) (*DomainResponse, error) {
+
+	// set schema version
+	setVersionHeader(req, schemaVersion)
+
+	// Look for optional args
+	if len(queryArgs) > 0 {
+		q := req.URL.Query()
+		if val, ok := queryArgs["contractId"]; ok {
+			q.Add("contractId", strings.TrimPrefix(val, "ctr_"))
+		}
+		if val, ok := queryArgs["gid"]; ok {
+			q.Add("gid", strings.TrimPrefix(val, "grp_"))
+		}
+		req.URL.RawQuery = q.Encode()
+	}
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+
+	// Network error
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "Domain",
+			name:             domain.Name,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	printHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "Domain", name: domain.Name, apiErrorMessage: err.Detail, err: err}
+	}
+
+	// TODO: What validation can we do? E.g. if not equivalent there was a concurrent change...
+	responseBody := &DomainResponse{}
+	// Unmarshall whole response body in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody, nil
+
+}
+
+// Create is a method applied to a domain object resulting in creation.
+func (domain *Domain) Create(queryArgs map[string]string) (*DomainResponse, error) {
+
+	req, err := client.NewJSONRequest(
+		Config,
+		"POST",
+		fmt.Sprintf("/config-gtm/v1/domains/"),
+		domain,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return domain.save(queryArgs, req)
+
+}
+
+// Update is a method applied to a domain object resulting in an update.
+func (domain *Domain) Update(queryArgs map[string]string) (*ResponseStatus, error) {
+
+	// Any validation to do?
+	req, err := client.NewJSONRequest(
+		Config,
+		"PUT",
+		fmt.Sprintf("/config-gtm/v1/domains/%s", domain.Name),
+		domain,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	stat, err := domain.save(queryArgs, req)
+	if err != nil {
+		return nil, err
+	}
+	return stat.Status, err
+}
+
+// Delete is a method applied to a domain object resulting in removal.
+func (domain *Domain) Delete() (*ResponseStatus, error) {
+
+	req, err := client.NewRequest(
+		Config,
+		"DELETE",
+		fmt.Sprintf("/config-gtm/v1/domains/%s", domain.Name),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Network error
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "Domain",
+			name:             domain.Name,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	printHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "Domain", name: domain.Name, apiErrorMessage: err.Detail, err: err}
+	}
+
+	responseBody := &ResponseBody{}
+	// Unmarshall whole response body in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody.Status, nil
+
+}
+
+// NullObjectAttributeStruct represents core and child null onject attributes
+type NullPerObjectAttributeStruct struct {
+	CoreObjectFields  map[string]string
+	ChildObjectFields map[string]interface{} // NullObjectAttributeStruct
+}
+
+// NullFieldMapStruct returned null Objects structure
+type NullFieldMapStruct struct {
+	Domain      NullPerObjectAttributeStruct            // entry is domain
+	Properties  map[string]NullPerObjectAttributeStruct // entries are properties
+	Datacenters map[string]NullPerObjectAttributeStruct // entries are datacenters
+	Resources   map[string]NullPerObjectAttributeStruct // entries are resources
+	CidrMaps    map[string]NullPerObjectAttributeStruct // entries are cidrmaps
+	GeoMaps     map[string]NullPerObjectAttributeStruct // entries are geomaps
+	AsMaps      map[string]NullPerObjectAttributeStruct // entries are asmaps
+}
+
+type ObjectMap map[string]interface{}
+
+// Retrieve map of null fields
+func (domain *Domain) NullFieldMap() (*NullFieldMapStruct, error) {
+
+	var nullFieldMap = &NullFieldMapStruct{}
+	var domFields = NullPerObjectAttributeStruct{}
+	domainMap := make(map[string]string)
+	var objMap = ObjectMap{}
+
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-gtm/v1/domains/%s", domain.Name),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	setVersionHeader(req, schemaVersion)
+	printHttpRequest(req, true)
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+	printHttpResponse(res, true)
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, CommonError{entityName: "Domain", name: domain.Name}
+	} else {
+		err = client.BodyJSON(res, &objMap)
+		if err != nil {
+			return nullFieldMap, err
+		}
+	}
+	for i, d := range objMap {
+		objval := fmt.Sprint(d)
+		if fmt.Sprintf("%T", d) == "<nil>" {
+			if objval == "<nil>" {
+				domainMap[makeFirstCharUpperCase(i)] = ""
+			}
+			continue
+		}
+		switch i {
+		case "properties":
+			nullFieldMap.Properties = processObjectList(d.([]interface{}))
+		case "datacenters":
+			nullFieldMap.Datacenters = processObjectList(d.([]interface{}))
+		case "resources":
+			nullFieldMap.Resources = processObjectList(d.([]interface{}))
+		case "cidrMaps":
+			nullFieldMap.CidrMaps = processObjectList(d.([]interface{}))
+		case "geographicMaps":
+			nullFieldMap.GeoMaps = processObjectList(d.([]interface{}))
+		case "asMaps":
+			nullFieldMap.AsMaps = processObjectList(d.([]interface{}))
+		}
+	}
+
+	domFields.CoreObjectFields = domainMap
+	nullFieldMap.Domain = domFields
+
+	return nullFieldMap, nil
+
+}
+
+func makeFirstCharUpperCase(origString string) string {
+
+	a := []rune(origString)
+	a[0] = unicode.ToUpper(a[0])
+	// hack
+	if origString == "cname" {
+		a[1] = unicode.ToUpper(a[1])
+	}
+	return string(a)
+}
+
+func processObjectList(objectList []interface{}) map[string]NullPerObjectAttributeStruct {
+
+	nullObjectsList := make(map[string]NullPerObjectAttributeStruct)
+	for _, obj := range objectList {
+		nullObjectFields := NullPerObjectAttributeStruct{}
+		objectName := ""
+		objectDCID := ""
+		objectMap := make(map[string]string)
+		objectChildList := make(map[string]interface{})
+		for objf, objd := range obj.(map[string]interface{}) {
+			objval := fmt.Sprint(objd)
+			switch fmt.Sprintf("%T", objd) {
+			case "<nil>":
+				if objval == "<nil>" {
+					objectMap[makeFirstCharUpperCase(objf)] = ""
+				}
+			case "map[string]interface {}":
+				// include null stand alone struct elements in core
+				for moname, movalue := range objd.(map[string]interface{}) {
+					if fmt.Sprintf("%T", movalue) == "<nil>" {
+						objectMap[makeFirstCharUpperCase(moname)] = ""
+					}
+				}
+			case "[]interface {}":
+				iSlice := objd.([]interface{})
+				if len(iSlice) > 0 && reflect.TypeOf(iSlice[0]).Kind() != reflect.String && reflect.TypeOf(iSlice[0]).Kind() != reflect.Int64 && reflect.TypeOf(iSlice[0]).Kind() != reflect.Float64 && reflect.TypeOf(iSlice[0]).Kind() != reflect.Int32 {
+					objectChildList[makeFirstCharUpperCase(objf)] = processObjectList(objd.([]interface{}))
+				}
+			default:
+				if objf == "name" {
+					objectName = objval
+				}
+				if objf == "datacenterId" {
+					objectDCID = objval
+				}
+			}
+		}
+		nullObjectFields.CoreObjectFields = objectMap
+		nullObjectFields.ChildObjectFields = objectChildList
+
+		if objectDCID == "" {
+			if objectName != "" {
+				nullObjectsList[objectName] = nullObjectFields
+			} else {
+				nullObjectsList["unknown"] = nullObjectFields // TODO: What if mnore than one?
+			}
+		} else {
+			nullObjectsList[objectDCID] = nullObjectFields
+		}
+	}
+
+	return nullObjectsList
+
+}

--- a/configgtm-v1_5/domain.go
+++ b/configgtm-v1_5/domain.go
@@ -2,16 +2,17 @@ package configgtm
 
 import (
 	"fmt"
-	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
 	"net/http"
 	"reflect"
 	"strings"
 	"unicode"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
 )
 
 //
 // Support gtm domains thru Edgegrid
-// Based on 1.4 Schema
+// Based on 1.5 Schema
 //
 
 // The Domain data structure represents a GTM domain

--- a/configgtm-v1_5/domain_test.go
+++ b/configgtm-v1_5/domain_test.go
@@ -1,0 +1,790 @@
+package configgtm
+
+import (
+	"testing"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/jsonhooks-v1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func instantiateDomain() *Domain {
+
+	domain := NewDomain(gtmTestDomain, "basic")
+	domainData := []byte(`{
+                                "cnameCoalescingEnabled" : false,
+                                "defaultErrorPenalty" : 75,
+                                "defaultHealthMax" : null,
+                                "defaultHealthMultiplier" : null,
+                                "defaultHealthThreshold" : null,
+                                "defaultMaxUnreachablePenalty" : null,
+                                "defaultSslClientCertificate" : null,
+                                "defaultSslClientPrivateKey" : null,
+                                "defaultTimeoutPenalty" : 25,
+                                "defaultUnreachableThreshold" : null,
+                                "emailNotificationList" : [ ],
+                                "endUserMappingEnabled" : false,
+                                "lastModified" : "2019-06-14T19:36:13.174+00:00",
+                                "lastModifiedBy" : "operator",
+                                "loadFeedback" : false,
+                                "mapUpdateInterval" : 600,
+                                "maxProperties" : 100,
+                                "maxResources" : 9999,
+                                "maxTestTimeout" : 60.0,
+                                "maxTTL" : 3600,
+                                "minPingableRegionFraction" : null,
+                                "minTestInterval" : 0,
+                                "minTTL" : 0,
+                                "modificationComments" : "Add Property testproperty",
+                                "name" : "gtmdomtest.akadns.net",
+                                "pingInterval" : null,
+                                "pingPacketSize" : null,
+                                "roundRobinPrefix" : null,
+                                "servermonitorLivenessCount" : null,
+                                "servermonitorLoadCount" : null,
+                                "servermonitorPool" : null,
+                                "type" : "basic",
+                                "status" : {
+                                        "message" : "Change Pending",
+                                        "changeId" : "df6c04e4-6327-4e0f-8872-bfe9fb2693d2",
+                                        "propagationStatus" : "PENDING",
+                                        "propagationStatusDate" : "2019-06-14T19:36:13.174+00:00",
+                                        "passingValidation" : true,
+                                        "links" : [ {
+                                                                "rel" : "self",
+                                                                "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current"
+                                        } ]
+                                },
+                                "loadImbalancePercentage" : null,
+                                "domainVersionId" : null,
+                                "resources" : [ ],
+                                "properties" : [ {
+                                        "backupCName" : null,
+                                        "backupIp" : null,
+                                        "balanceByDownloadScore" : false,
+                                        "cname" : null,
+                                        "comments" : null,
+                                        "dynamicTTL" : 300,
+                                        "failoverDelay" : null,
+                                        "failbackDelay" : null,
+                                        "ghostDemandReporting" : false,
+                                        "handoutMode" : "normal",
+                                        "handoutLimit" : 1,
+                                        "healthMax" : null,
+                                        "healthMultiplier" : null,
+                                        "healthThreshold" : null,
+                                        "lastModified" : "2019-06-14T19:36:13.174+00:00",
+                                        "livenessTests" : [ ],
+                                        "loadImbalancePercentage" : null,
+                                        "mapName" : null,
+                                        "maxUnreachablePenalty" : null,
+                                        "minLiveFraction" : null,
+                                        "mxRecords" : [ ],
+                                        "name" : "testproperty",
+                                        "scoreAggregationType" : "median",
+                                        "stickinessBonusConstant" : null,
+                                        "stickinessBonusPercentage" : null,
+                                        "staticTTL" : null,
+                                        "trafficTargets" : [ {
+                                                "datacenterId" : 3131,
+                                                "enabled" : true,
+                                                "weight" : 100.0,
+                                                "handoutCName" : null,
+                                                "name" : null,
+                                                "servers" : [ "1.2.3.4" ]
+                                        } ],
+                                        "type" : "performance",
+                                        "unreachableThreshold" : null,
+                                        "useComputedTargets" : false,
+                                        "weightedHashBitsForIPv4" : null,
+                                        "weightedHashBitsForIPv6" : null,
+                                        "ipv6" : false,
+                                        "links" : [ {
+                                                "rel" : "self",
+                                                "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/properties/testproperty"
+                                        } ]
+                                } ],
+                                "datacenters" : [ {
+                                        "datacenterId" : 3131,
+                                        "nickname" : "testDC1",
+                                        "scorePenalty" : 0,
+                                        "city" : null,
+                                        "stateOrProvince" : null,
+                                        "country" : null,
+                                        "latitude" : null,
+                                        "longitude" : null,
+                                        "cloneOf" : null,
+                                        "virtual" : true,
+                                        "defaultLoadObject" : null,
+                                        "continent" : null,
+                                        "servermonitorPool" : null,
+                                        "servermonitorLivenessCount" : null,
+                                        "servermonitorLoadCount" : null,
+                                        "pingInterval" : null,
+                                        "pingPacketSize" : null,
+                                        "cloudServerTargeting" : false,
+                                        "cloudServerHostHeaderOverride" : false,
+                                        "links" : [ {
+                                                "rel" : "self",
+                                                "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/datacenters/3131"
+                                        } ]
+                                } ],
+                                "geographicMaps" : [ ],
+                                "cidrMaps" : [ ],
+                                "asMaps" : [ ],
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net"
+                                }, {
+                                        "rel" : "datacenters",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/datacenters"
+                                }, {
+                                        "rel" : "properties",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/properties"
+                                }, {
+                                        "rel" : "geographic-maps",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/geographic-maps"
+                                }, {
+                                        "rel" : "cidr-maps",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/cidr-maps"
+                                }, {
+                                        "rel" : "resources",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/resources"
+                                }, {
+                                        "rel" : "as-maps",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/as-maps"
+                                } ]
+                       }`)
+	jsonhooks.Unmarshal(domainData, domain)
+
+	return domain
+
+}
+
+// Verify GetListDomains. Sould pass, e.g. no API errors and non nil list.
+func TestListDomains(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains")
+	mock.
+		Get("/config-gtm/v1/domains").
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "items" : [ {
+                                "name" : "gtmdomtest.akadns.net",
+                                "status" : "Change Pending",
+                                "acgId" : "1-3CV382",
+                                "lastModified" : "2019-06-06T19:07:20.000+00:00",
+                                "lastModifiedBy" : "operator",
+                                "changeId" : "c3e1b771-2500-40c9-a7da-6c3cdbce1936",
+                                "activationState" : "PENDING",
+                                "modificationComments" : "mock test",
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net"
+                                } ]
+                        } ]
+                   }`)
+
+	Init(config)
+
+	domainsList, err := ListDomains()
+	assert.NoError(t, err)
+	assert.NotEqual(t, domainsList, nil)
+	assert.Equal(t, "gtmdomtest.akadns.net", domainsList[0].Name)
+
+}
+
+// Verify GetDomain. Name hardcoded. Should pass, e.g. no API errors and domain returned
+func TestGetDomain(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain)
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                          "cidrMaps": [], 
+                          "datacenters": [
+                              {
+                                  "city": "Snæfellsjökull", 
+                                  "cloneOf": null, 
+                                  "cloudServerTargeting": false, 
+                                  "continent": "EU", 
+                                  "country": "IS", 
+                                  "datacenterId": 3132, 
+                                  "defaultLoadObject": {
+                                       "loadObject": null, 
+                                       "loadObjectPort": 0, 
+                                       "loadServers": null
+                                   }, 
+                                   "latitude": 64.808, 
+                                   "links": [
+                                       {
+                                            "href": "https://akab-ymtebc45gco3ypzj-apz4yxpek55y7fyv.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/datacenters/3132", 
+                                            "rel": "self"
+                                       }
+                                    ], 
+                                    "longitude": -23.776, 
+                                    "nickname": "property_test_dc2", 
+                                    "stateOrProvince": null, 
+                                    "virtual": true
+                              }, 
+                              {
+                                    "city": "Philadelphia", 
+                                    "cloneOf": null, 
+                                    "cloudServerTargeting": true, 
+                                    "continent": "NA", 
+                                    "country": "US", 
+                                    "datacenterId": 3133, 
+                                    "defaultLoadObject": {
+                                         "loadObject": null, 
+                                         "loadObjectPort": 0, 
+                                         "loadServers": null
+                                    }, 
+                                    "latitude": 39.95, 
+                                    "links": [
+                                        {
+                                             "href": "https://akab-ymtebc45gco3ypzj-apz4yxpek55y7fyv.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/datacenters/3133", 
+                                             "rel": "self"
+                                        }
+                                     ], 
+                                     "longitude": -75.167, 
+                                     "nickname": "property_test_dc3", 
+                                     "stateOrProvince": null, 
+                                     "virtual": true
+                              }, 
+                              {
+                                     "city": "Downpat", 
+                                     "cloneOf": null, 
+                                     "cloudServerTargeting": false, 
+                                     "continent": "EU", 
+                                     "country": "GB", 
+                                     "datacenterId": 3131, 
+                                     "defaultLoadObject": {
+                                           "loadObject": null, 
+                                           "loadObjectPort": 0, 
+                                           "loadServers": null
+                                     }, 
+                                     "latitude": 54.367, 
+                                     "links": [
+                                         {
+                                              "href": "https://akab-ymtebc45gco3ypzj-apz4yxpek55y7fyv.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/datacenters/3131", 
+                                              "rel": "self"
+                                         }
+                                     ], 
+                                     "longitude": -5.582, 
+                                     "nickname": "property_test_dc1", 
+                                     "stateOrProvince": "ha", 
+                                     "virtual": true
+                              }
+                          ], 
+                          "defaultErrorPenalty": 75, 
+                          "defaultSslClientCertificate": null, 
+                          "defaultSslClientPrivateKey": null, 
+                          "defaultTimeoutPenalty": 25, 
+                          "emailNotificationList": [], 
+                          "geographicMaps": [], 
+                          "lastModified": "2019-04-25T14:53:12.000+00:00", 
+                          "lastModifiedBy": "operator", 
+                          "links": [
+                              {
+                                   "href": "https://akab-ymtebc45gco3ypzj-apz4yxpek55y7fyv.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net", 
+                                   "rel": "self"
+                              }, 
+                              {
+                                   "href": "https://akab-ymtebc45gco3ypzj-apz4yxpek55y7fyv.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/datacenters", 
+                                   "rel": "datacenters"
+                              }, 
+                              {
+                                   "href": "https://akab-ymtebc45gco3ypzj-apz4yxpek55y7fyv.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/properties", 
+                                   "rel": "properties"
+                              }, 
+                              {
+                                   "href": "https://akab-ymtebc45gco3ypzj-apz4yxpek55y7fyv.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/geographic-maps", 
+                                   "rel": "geographic-maps"
+                              }, 
+                              {
+                                   "href": "https://akab-ymtebc45gco3ypzj-apz4yxpek55y7fyv.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/cidr-maps", 
+                                   "rel": "cidr-maps"
+                              }, 
+                              {
+                                   "href": "https://akab-ymtebc45gco3ypzj-apz4yxpek55y7fyv.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/resources", 
+                                   "rel": "resources"
+                              }
+                          ], 
+                          "loadFeedback": false, 
+                          "loadImbalancePercentage": 10.0, 
+                          "modificationComments": "Edit Property test_property", 
+                          "name": "gtmdomtest.akadns.net", 
+                          "properties": [
+                               {
+                                    "backupCName": null, 
+                                    "backupIp": null, 
+                                    "balanceByDownloadScore": false, 
+                                    "cname": "www.boo.wow", 
+                                    "comments": null, 
+                                    "dynamicTTL": 300, 
+                                    "failbackDelay": 0, 
+                                    "failoverDelay": 0, 
+                                    "handoutMode": "normal", 
+                                    "healthMax": null, 
+                                    "healthMultiplier": null, 
+                                    "healthThreshold": null, 
+                                    "ipv6": false, 
+                                    "lastModified": "2019-04-25T14:53:12.000+00:00", 
+                                    "links": [
+                                         {
+                                              "href": "https://akab-ymtebc45gco3ypzj-apz4yxpek55y7fyv.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/properties/test_property", 
+                                              "rel": "self"
+                                         }
+                                    ], 
+                                    "livenessTests": [
+                                         {
+                                               "disableNonstandardPortWarning": false, 
+                                               "hostHeader": null, 
+                                               "httpError3xx": true, 
+                                               "httpError4xx": true, 
+                                               "httpError5xx": true, 
+                                               "name": "health check", 
+                                               "requestString": null, 
+                                               "responseString": null, 
+                                               "sslClientCertificate": null, 
+                                               "sslClientPrivateKey": null, 
+                                               "testInterval": 60, 
+                                               "testObject": "/status", 
+                                               "testObjectPassword": null, 
+                                               "testObjectPort": 80, 
+                                               "testObjectProtocol": "HTTP", 
+                                               "testObjectUsername": null, 
+                                               "testTimeout": 25.0
+                                         }
+                                    ], 
+                                    "loadImbalancePercentage": 10.0, 
+                                    "mapName": null, 
+                                    "maxUnreachablePenalty": null, 
+                                    "mxRecords": [], 
+                                    "name": "test_property", 
+                                    "scoreAggregationType": "mean", 
+                                    "staticTTL": 600, 
+                                    "stickinessBonusConstant": null, 
+                                    "stickinessBonusPercentage": 50, 
+                                    "trafficTargets": [
+                                         {
+                                              "datacenterId": 3131, 
+                                              "enabled": true, 
+                                              "handoutCName": null, 
+                                              "name": null, 
+                                              "servers": [
+                                                   "1.2.3.4", 
+                                                   "1.2.3.5"
+                                              ], 
+                                              "weight": 50.0
+                                         }, 
+                                         {
+                                              "datacenterId": 3132, 
+                                              "enabled": true, 
+                                              "handoutCName": "www.google.com", 
+                                              "name": null, 
+                                              "servers": [], 
+                                              "weight": 25.0
+                                         }, 
+                                         {
+                                              "datacenterId": 3133, 
+                                              "enabled": true, 
+                                              "handoutCName": "www.comcast.com", 
+                                              "name": null, 
+                                              "servers": [
+                                                    "www.comcast.com"
+                                              ], 
+                                              "weight": 25.0
+                                         }
+                                    ], 
+                                    "type": "weighted-round-robin", 
+                                    "unreachableThreshold": null, 
+                                    "useComputedTargets": false
+                               }
+                          ], 
+                          "resources": [], 
+                          "status": {
+                               "changeId": "40e36abd-bfb2-4635-9fca-62175cf17007", 
+                               "links": [
+                                     {
+                                          "href": "https://akab-ymtebc45gco3ypzj-apz4yxpek55y7fyv.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current", 
+                                          "rel": "self"
+                                     }
+                               ], 
+                               "message": "Current configuration has been propagated to all GTM nameservers", 
+                               "passingValidation": true, 
+                               "propagationStatus": "COMPLETE", 
+                               "propagationStatusDate": "2019-04-25T14:54:00.000+00:00"
+                          }, 
+                          "type": "weighted"
+                }`)
+
+	Init(config)
+
+	testDomain, err := GetDomain(gtmTestDomain)
+
+	assert.NoError(t, err)
+	assert.Equal(t, gtmTestDomain, testDomain.Name)
+
+}
+
+// Verify failed case for GetDomain. Should pass, e.g. no API errors and domain not found
+func TestGetBadDomain(t *testing.T) {
+
+	baddomainname := "baddomainname.me"
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + baddomainname)
+	mock.
+		Get("/config-gtm/v1/domains/"+baddomainname).
+		HeaderPresent("Authorization").
+		Reply(404).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                }`)
+
+	Init(config)
+
+	_, err := GetDomain(baddomainname)
+	assert.Error(t, err)
+
+}
+
+// Test Create domain. Name is hardcoded so this will effectively be an update. What happens to existing?
+func TestCreateDomain(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains")
+	mock.
+		Post("/config-gtm/v1/domains/").
+		HeaderPresent("Authorization").
+		Reply(201).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "resource" : {
+                                "cnameCoalescingEnabled" : false,
+                                "defaultErrorPenalty" : 75,
+                                "defaultHealthMax" : null,
+                                "defaultHealthMultiplier" : null,
+                                "defaultHealthThreshold" : null,
+                                "defaultMaxUnreachablePenalty" : null,
+                                "defaultSslClientCertificate" : null,
+                                "defaultSslClientPrivateKey" : null,
+                                "defaultTimeoutPenalty" : 25,
+                                "defaultUnreachableThreshold" : null,
+                                "emailNotificationList" : [ ],
+                                "endUserMappingEnabled" : false,
+                                "lastModified" : "2019-06-24T18:48:57.787+00:00",
+                                "lastModifiedBy" : "operator",
+                                "loadFeedback" : false,
+                                "mapUpdateInterval" : 0,
+                                "maxProperties" : 0,
+                                "maxResources" : 512,
+                                "maxTestTimeout" : 0.0,
+                                "maxTTL" : 0,
+                                "minPingableRegionFraction" : null,
+                                "minTestInterval" : 0,
+                                "minTTL" : 0,
+                                "modificationComments" : null,
+                                "name" : "gtmdomtest.akadns.net",
+                                "pingInterval" : null,
+                                "pingPacketSize" : null,
+                                "roundRobinPrefix" : null,
+                                "servermonitorLivenessCount" : null,
+                                "servermonitorLoadCount" : null,
+                                "servermonitorPool" : null,
+                                "type" : "basic",
+                                "status" : {
+                                        "message" : "Change Pending",
+                                        "changeId" : "539872cc-6ba6-4429-acd5-90bab7fb5e9d",
+                                        "propagationStatus" : "PENDING",
+                                        "propagationStatusDate" : "2019-06-24T18:48:57.787+00:00",
+                                        "passingValidation" : true,
+                                        "links" : [ {
+                                                "rel" : "self",
+                                                "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current"
+                                        } ]
+                                },
+                                "loadImbalancePercentage" : null,
+                                "domainVersionId" : null,
+                                "resources" : [ ],
+                                "properties" : [ ],
+                                "datacenters" : [ ],
+                                "geographicMaps" : [ ],
+                                "cidrMaps" : [ ],
+                                "asMaps" : [ ],
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net"
+                                    }, {
+                                        "rel" : "datacenters",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/datacenters"
+                                    }, {
+                                        "rel" : "properties",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/properties"
+                                    }, {
+                                        "rel" : "geographic-maps",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/geographic-maps"
+                                    }, {
+                                        "rel" : "cidr-maps",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/cidr-maps"
+                                    }, {
+                                        "rel" : "resources",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/resources"
+                                    }, {
+                                        "rel" : "as-maps",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/as-maps"
+                                    } ]
+                                },
+                        "status" : {
+                                "message" : "Change Pending",
+                                "changeId" : "539872cc-6ba6-4429-acd5-90bab7fb5e9d",
+                                "propagationStatus" : "PENDING",
+                                "propagationStatusDate" : "2019-06-24T18:48:57.787+00:00",
+                                "passingValidation" : true,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current"
+                                } ]
+                        }
+                }`)
+
+	Init(config)
+
+	testDomain := NewDomain(gtmTestDomain, "basic")
+	qArgs := make(map[string]string)
+
+	statResponse, err := testDomain.Create(qArgs)
+	require.NoError(t, err)
+	assert.Equal(t, gtmTestDomain, statResponse.Resource.Name)
+
+}
+
+func TestUpdateDomain(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain)
+	mock.
+		Put("/config-gtm/v1/domains/"+gtmTestDomain).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "resource" : {
+                                "cnameCoalescingEnabled" : false,
+                                "defaultErrorPenalty" : 75,
+                                "defaultHealthMax" : null,
+                                "defaultHealthMultiplier" : null,
+                                "defaultHealthThreshold" : null,
+                                "defaultMaxUnreachablePenalty" : null,
+                                "defaultSslClientCertificate" : null,
+                                "defaultSslClientPrivateKey" : null,
+                                "defaultTimeoutPenalty" : 25,
+                                "defaultUnreachableThreshold" : null,
+                                "emailNotificationList" : [ ],
+                                "endUserMappingEnabled" : false,
+                                "lastModified" : "2019-06-14T19:36:13.174+00:00",
+                                "lastModifiedBy" : "operator",
+                                "loadFeedback" : false,
+                                "mapUpdateInterval" : 600,
+                                "maxProperties" : 100,
+                                "maxResources" : 9999,
+                                "maxTestTimeout" : 60.0,
+                                "maxTTL" : 3600,
+                                "minPingableRegionFraction" : null,
+                                "minTestInterval" : 0,
+                                "minTTL" : 0,
+                                "modificationComments" : "Add Property testproperty",
+                                "name" : "gtmdomtest.akadns.net",
+                                "pingInterval" : null,
+                                "pingPacketSize" : null,
+                                "roundRobinPrefix" : null,
+                                "servermonitorLivenessCount" : null,
+                                "servermonitorLoadCount" : null,
+                                "servermonitorPool" : null,
+                                "type" : "basic",
+                                "status" : {
+                                        "message" : "Change Pending",
+                                        "changeId" : "df6c04e4-6327-4e0f-8872-bfe9fb2693d2",
+                                        "propagationStatus" : "PENDING",
+                                        "propagationStatusDate" : "2019-06-14T19:36:13.174+00:00",
+                                        "passingValidation" : true,
+                                        "links" : [ {
+                                                                "rel" : "self",
+                                                                "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current"
+                                        } ]
+                                },
+                                "loadImbalancePercentage" : null,
+                                "domainVersionId" : null,
+                                "resources" : [ ],
+                                "properties" : [ {
+                                        "backupCName" : null,
+                                        "backupIp" : null,
+                                        "balanceByDownloadScore" : false,
+                                        "cname" : null,
+                                        "comments" : null,
+                                        "dynamicTTL" : 300,
+                                        "failoverDelay" : null,
+                                        "failbackDelay" : null,
+                                        "ghostDemandReporting" : false,
+                                        "handoutMode" : "normal",
+                                        "handoutLimit" : 1,
+                                        "healthMax" : null,
+                                        "healthMultiplier" : null,
+                                        "healthThreshold" : null,
+                                        "lastModified" : "2019-06-14T19:36:13.174+00:00",
+                                        "livenessTests" : [ ],
+                                        "loadImbalancePercentage" : null,
+                                        "mapName" : null,
+                                        "maxUnreachablePenalty" : null,
+                                        "minLiveFraction" : null,
+                                        "mxRecords" : [ ],
+                                        "name" : "testproperty",
+                                        "scoreAggregationType" : "median",
+                                        "stickinessBonusConstant" : null,
+                                        "stickinessBonusPercentage" : null,
+                                        "staticTTL" : null,
+                                        "trafficTargets" : [ {
+                                                "datacenterId" : 3131,
+                                                "enabled" : true,
+                                                "weight" : 100.0,
+                                                "handoutCName" : null,
+                                                "name" : null,
+                                                "servers" : [ "1.2.3.4" ]
+                                        } ],
+                                        "type" : "performance",
+                                        "unreachableThreshold" : null,
+                                        "useComputedTargets" : false,
+                                        "weightedHashBitsForIPv4" : null,
+                                        "weightedHashBitsForIPv6" : null,
+                                        "ipv6" : false,
+                                        "links" : [ {
+                                                "rel" : "self",
+                                                "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/properties/testproperty"
+                                        } ]
+                                } ],
+                                "datacenters" : [ {
+                                        "datacenterId" : 3131,
+                                        "nickname" : "testDC1",
+                                        "scorePenalty" : 0,
+                                        "city" : null,
+                                        "stateOrProvince" : null,
+                                        "country" : null,
+                                        "latitude" : null,
+                                        "longitude" : null,
+                                        "cloneOf" : null,
+                                        "virtual" : true,
+                                        "defaultLoadObject" : null,
+                                        "continent" : null,
+                                        "servermonitorPool" : null,
+                                        "servermonitorLivenessCount" : null,
+                                        "servermonitorLoadCount" : null,
+                                        "pingInterval" : null,
+                                        "pingPacketSize" : null,
+                                        "cloudServerTargeting" : false,
+                                        "cloudServerHostHeaderOverride" : false,
+                                        "links" : [ {
+                                                "rel" : "self",
+                                                "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/datacenters/3131"
+                                        } ]
+                                } ],
+                                "geographicMaps" : [ ],
+                                "cidrMaps" : [ ],
+                                "asMaps" : [ ],
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net"
+                                }, {
+                                        "rel" : "datacenters",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/datacenters"
+                                }, {
+                                        "rel" : "properties",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/properties"
+                                }, {
+                                        "rel" : "geographic-maps",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/geographic-maps"
+                                }, {
+                                        "rel" : "cidr-maps",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/cidr-maps"
+                                }, {
+                                        "rel" : "resources",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/resources"
+                                }, {
+                                        "rel" : "as-maps",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/as-maps"
+                                } ]
+                        },
+                        "status" : {
+                                      "message" : "Change Pending",
+                                      "changeId" : "df6c04e4-6327-4e0f-8872-bfe9fb2693d2",
+                                      "propagationStatus" : "PENDING",
+                                      "propagationStatusDate" : "2019-06-14T19:36:13.174+00:00",
+                                      "passingValidation" : true,
+                                      "links" : [ {
+                                              "rel" : "self",
+                                              "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current"
+                                      } ]
+                        }            
+                }`)
+
+	Init(config)
+
+	testDomain := instantiateDomain()
+	//testDomain.MaxResources = 9999
+	qArgs := make(map[string]string)
+	statResp, err := testDomain.Update(qArgs)
+	require.NoError(t, err)
+	assert.Equal(t, statResp.ChangeId, "df6c04e4-6327-4e0f-8872-bfe9fb2693d2")
+
+}
+
+/* Future. Presently no domain Delete endpoint.
+func TestDeleteDomain(t *testing.T) {
+
+        defer gock.Off()
+
+        mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/"+gtmTestDomain)
+        mock.
+                Delete("/config-gtm/v1/domains/"+gtmTestDomain).
+                HeaderPresent("Authorization").
+                Reply(200).
+                SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+                BodyString(`{
+                        "resource" : null,
+                        "status" : {
+                               "changeId": "40e36abd-bfb2-4635-9fca-62175cf17007",
+                               "links": [
+                                     {
+                                          "href": "https://akab-ymtebc45gco3ypzj-apz4yxpek55y7fyv.luna.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current",
+                                          "rel": "self"
+                                     }
+                               ],
+                               "message": "Change Pending",
+                               "passingValidation": true,
+                               "propagationStatus": "PENDING",
+                               "propagationStatusDate": "2019-04-25T14:54:00.000+00:00"
+                          },
+                }`)
+
+        Init(config)
+
+        getDomain := instantiateDomain()
+
+        _, err := getDomain.Delete()
+        assert.NoError(t, err)
+
+}
+*/

--- a/configgtm-v1_5/domain_test.go
+++ b/configgtm-v1_5/domain_test.go
@@ -173,7 +173,7 @@ func TestListDomains(t *testing.T) {
 		Get("/config-gtm/v1/domains").
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "items" : [ {
                                 "name" : "gtmdomtest.akadns.net",
@@ -210,7 +210,7 @@ func TestGetDomain(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                           "cidrMaps": [], 
                           "datacenters": [
@@ -450,7 +450,7 @@ func TestGetBadDomain(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+baddomainname).
 		HeaderPresent("Authorization").
 		Reply(404).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                 }`)
 
@@ -471,7 +471,7 @@ func TestCreateDomain(t *testing.T) {
 		Post("/config-gtm/v1/domains/").
 		HeaderPresent("Authorization").
 		Reply(201).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "resource" : {
                                 "cnameCoalescingEnabled" : false,
@@ -581,7 +581,7 @@ func TestUpdateDomain(t *testing.T) {
 		Put("/config-gtm/v1/domains/"+gtmTestDomain).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "resource" : {
                                 "cnameCoalescingEnabled" : false,
@@ -761,7 +761,7 @@ func TestDeleteDomain(t *testing.T) {
                 Delete("/config-gtm/v1/domains/"+gtmTestDomain).
                 HeaderPresent("Authorization").
                 Reply(200).
-                SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+                SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
                 BodyString(`{
                         "resource" : null,
                         "status" : {

--- a/configgtm-v1_5/errors.go
+++ b/configgtm-v1_5/errors.go
@@ -1,0 +1,108 @@
+package configgtm
+
+import (
+	"fmt"
+)
+
+type ConfigGTMError interface {
+	error
+	Network() bool
+	NotFound() bool
+	FailedToSave() bool
+	ValidationFailed() bool
+}
+
+func IsConfigGTMError(e error) bool {
+	_, ok := e.(ConfigGTMError)
+	return ok
+}
+
+type CommonError struct {
+	entityName       string
+	name             string
+	httpErrorMessage string
+	apiErrorMessage  string
+	err              error
+}
+
+func (e CommonError) SetItem(itemName string, itemVal interface{}) {
+	switch itemName {
+	case "entityName":
+		e.entityName = itemVal.(string)
+	case "name":
+		e.name = itemVal.(string)
+	case "httpErrorMessage":
+		e.httpErrorMessage = itemVal.(string)
+	case "apiErrorMessage":
+		e.apiErrorMessage = itemVal.(string)
+	case "err":
+		e.err = itemVal.(error)
+	}
+}
+
+func (e CommonError) GetItem(itemName string) interface{} {
+	switch itemName {
+	case "entityName":
+		return e.entityName
+	case "name":
+		return e.name
+	case "httpErrorMessage":
+		return e.httpErrorMessage
+	case "apiErrorMessage":
+		return e.apiErrorMessage
+	case "err":
+		return e.err
+	}
+
+	return nil
+}
+
+func (e CommonError) Network() bool {
+	if e.httpErrorMessage != "" {
+		return true
+	}
+	return false
+}
+
+func (e CommonError) NotFound() bool {
+	if e.err == nil && e.httpErrorMessage == "" && e.apiErrorMessage == "" {
+		return true
+	}
+	return false
+}
+
+func (CommonError) FailedToSave() bool {
+	return false
+}
+
+func (e CommonError) ValidationFailed() bool {
+	if e.apiErrorMessage != "" {
+		return true
+	}
+	return false
+}
+
+func (e CommonError) Error() string {
+
+	if e.Network() {
+		return fmt.Sprintf("%s \"%s\" network error: [%s]", e.entityName, e.name, e.httpErrorMessage)
+	}
+
+	if e.NotFound() {
+		return fmt.Sprintf("%s \"%s\" not found.", e.entityName, e.name)
+	}
+
+	if e.FailedToSave() {
+		return fmt.Sprintf("%s \"%s\" failed to save: [%s]", e.entityName, e.name, e.err.Error())
+	}
+
+	if e.ValidationFailed() {
+		return fmt.Sprintf("%s \"%s\" validation failed: [%s]", e.entityName, e.name, e.apiErrorMessage)
+	}
+
+	if e.err != nil {
+		return e.err.Error()
+	}
+
+	return "<nil>"
+}

--- a/configgtm-v1_5/geomap.go
+++ b/configgtm-v1_5/geomap.go
@@ -1,0 +1,248 @@
+package configgtm
+
+import (
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
+
+	"fmt"
+)
+
+//
+// Handle Operations on gtm geomaps
+// Based on 1.4 schema
+//
+
+// GeoAssigment represents a GTM geo assignment element
+type GeoAssignment struct {
+	DatacenterBase
+	Countries []string `json:"countries"`
+}
+
+// GeoMap  represents a GTM GeoMap
+type GeoMap struct {
+	DefaultDatacenter *DatacenterBase  `json:"defaultDatacenter"`
+	Assignments       []*GeoAssignment `json:"assignments,omitempty"`
+	Name              string           `json:"name"`
+	Links             []*Link          `json:"links,omitempty"`
+}
+
+// GeoMapList represents the returned GTM GeoMap List body
+type GeoMapList struct {
+	GeoMapItems []*GeoMap `json:"items"`
+}
+
+// NewGeoMap creates a new GeoMap object
+func NewGeoMap(name string) *GeoMap {
+	geomap := &GeoMap{Name: name}
+	return geomap
+}
+
+// ListGeoMap retreieves all GeoMaps
+func ListGeoMaps(domainName string) ([]*GeoMap, error) {
+	geos := &GeoMapList{}
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/geographic-maps", domainName),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	printHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, CommonError{entityName: "geoMap"}
+	}
+	err = client.BodyJSON(res, geos)
+	if err != nil {
+		return nil, err
+	}
+
+	return geos.GeoMapItems, nil
+
+}
+
+// GetGeoMap retrieves a GeoMap with the given name.
+func GetGeoMap(name, domainName string) (*GeoMap, error) {
+	geo := NewGeoMap(name)
+
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/geographic-maps/%s", domainName, name),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	printHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, CommonError{entityName: "GeographicMap", name: name}
+	} else {
+		err = client.BodyJSON(res, geo)
+		if err != nil {
+			return nil, err
+		}
+
+		return geo, nil
+	}
+}
+
+// Instantiate new Assignment struct
+func (geo *GeoMap) NewAssignment(dcID int, nickname string) *GeoAssignment {
+	geoAssign := &GeoAssignment{}
+	geoAssign.DatacenterId = dcID
+	geoAssign.Nickname = nickname
+
+	return geoAssign
+
+}
+
+// Instantiate new Default Datacenter Struct
+func (geo *GeoMap) NewDefaultDatacenter(dcID int) *DatacenterBase {
+	return &DatacenterBase{DatacenterId: dcID}
+}
+
+// Create GeoMap in provided domain
+func (geo *GeoMap) Create(domainName string) (*GeoMapResponse, error) {
+
+	// Use common code. Any specific validation needed?
+
+	return geo.save(domainName)
+
+}
+
+// Update GeoMap in given domain
+func (geo *GeoMap) Update(domainName string) (*ResponseStatus, error) {
+
+	// common code
+
+	stat, err := geo.save(domainName)
+	if err != nil {
+		return nil, err
+	}
+	return stat.Status, err
+
+}
+
+// Save GeoMap in given domain. Common path for Create and Update.
+func (geo *GeoMap) save(domainName string) (*GeoMapResponse, error) {
+
+	req, err := client.NewJSONRequest(
+		Config,
+		"PUT",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/geographic-maps/%s", domainName, geo.Name),
+		geo,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+
+	// Network error
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "geographicMap",
+			name:             geo.Name,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	printHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "geographicMap", name: geo.Name, apiErrorMessage: err.Detail, err: err}
+	}
+
+	responseBody := &GeoMapResponse{}
+	// Unmarshall whole response body for updated entity and in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody, nil
+}
+
+// Delete GeoMap method
+func (geo *GeoMap) Delete(domainName string) (*ResponseStatus, error) {
+
+	req, err := client.NewRequest(
+		Config,
+		"DELETE",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/geographic-maps/%s", domainName, geo.Name),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Network error
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "geographicMap",
+			name:             geo.Name,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	printHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "geographicMap", name: geo.Name, apiErrorMessage: err.Detail, err: err}
+	}
+
+	responseBody := &ResponseBody{}
+	// Unmarshall whole response body in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody.Status, nil
+}

--- a/configgtm-v1_5/geomap.go
+++ b/configgtm-v1_5/geomap.go
@@ -8,7 +8,7 @@ import (
 
 //
 // Handle Operations on gtm geomaps
-// Based on 1.4 schema
+// Based on 1.5 schema
 //
 
 // GeoAssigment represents a GTM geo assignment element

--- a/configgtm-v1_5/geomap_test.go
+++ b/configgtm-v1_5/geomap_test.go
@@ -1,0 +1,276 @@
+package configgtm
+
+import (
+	"testing"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/jsonhooks-v1"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
+)
+
+var GtmTestGeoMap = "testGeoMap"
+
+func instantiateGeoMap() *GeoMap {
+
+	geoMap := NewGeoMap(GtmTestGeoMap)
+	geoMapData := []byte(`{
+                        "assignments": [ {
+                                "countries": [ "GB", "IE" ],
+                                "datacenterId": 3133,
+                                "nickname": "UK and Ireland users"
+                        } ],
+                        "defaultDatacenter": {
+                                "datacenterId": 5400,
+                                "nickname": "Default Mapping"
+                        },
+                        "links": [ {
+                                "href": "/config-gtm/v1/domains/example.akadns.net/geographic-maps/UK%20Delivery",
+                                "rel": "self"
+                        } ],
+                        "name": "testGeoMap"
+              }`)
+	jsonhooks.Unmarshal(geoMapData, geoMap)
+
+	return geoMap
+
+}
+
+// Verify ListGeoMap. Name hardcoded. Should pass, e.g. no API errors and resource returned
+func TestListGeoMaps(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/geographic-maps")
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/geographic-maps").
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                    "items" : [ {
+                        "assignments": [ {
+                                "countries": [ "GB", "IE" ],
+                                "datacenterId": 3133,
+                                "nickname": "UK and Ireland users"
+                        } ],
+                        "defaultDatacenter": {
+                                "datacenterId": 5400,
+                                "nickname": "Default Mapping"
+                        },
+                        "links": [ {
+                                "href": "/config-gtm/v1/domains/example.akadns.net/geographic-maps/UK%20Delivery",
+                                "rel": "self"
+                        } ],
+                        "name": "testGeoMap"
+                    } ]
+               }`)
+
+	Init(config)
+
+	testGeoMap, err := ListGeoMaps(gtmTestDomain)
+	assert.NoError(t, err)
+	assert.IsType(t, &GeoMap{}, testGeoMap[0])
+	assert.Equal(t, GtmTestGeoMap, testGeoMap[0].Name)
+
+}
+
+// Verify GetGeoMap. Name hardcoded. Should pass, e.g. no API errors and resource returned
+func TestGetGeoMap(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/geographic-maps/" + GtmTestGeoMap)
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/geographic-maps/"+GtmTestGeoMap).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "assignments": [ {
+                                "countries": [ "GB", "IE" ],
+                                "datacenterId": 3133,
+                                "nickname": "UK and Ireland users"
+                        } ],
+                        "defaultDatacenter": {
+                                "datacenterId": 5400,
+                                "nickname": "Default Mapping"
+                        },
+                        "links": [ {
+                                "href": "/config-gtm/v1/domains/example.akadns.net/geographic-maps/UK%20Delivery",
+                                "rel": "self"
+                        } ],
+                        "name": "testGeoMap"
+               }`)
+
+	Init(config)
+
+	testGeoMap, err := GetGeoMap(GtmTestGeoMap, gtmTestDomain)
+	assert.NoError(t, err)
+	assert.IsType(t, &GeoMap{}, testGeoMap)
+	assert.Equal(t, GtmTestGeoMap, testGeoMap.Name)
+
+}
+
+// Verify failed case for GetGeoMap. Should pass, e.g. no API errors and domain not found
+func TestGetBadGeoMap(t *testing.T) {
+
+	badName := "somebadname"
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/geographic-maps/" + badName)
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/geographic-maps/"+badName).
+		HeaderPresent("Authorization").
+		Reply(404).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                }`)
+
+	Init(config)
+
+	_, err := GetGeoMap(badName, gtmTestDomain)
+	assert.Error(t, err)
+
+}
+
+// Test Create GeoMap.
+func TestCreateGeoMap(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/geographic-maps/" + GtmTestGeoMap)
+	mock.
+		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/geographic-maps/"+GtmTestGeoMap).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                    "resource" : {
+                        "assignments": [ {
+                                "countries": [ "GB", "IE" ],
+                                "datacenterId": 3133,
+                                "nickname": "UK and Ireland users"
+                        } ],
+                        "defaultDatacenter": {
+                                "datacenterId": 5400,
+                                "nickname": "Default Mapping"
+                        },
+                        "links": [ {
+                                "href": "/config-gtm/v1/domains/example.akadns.net/geographic-maps/UK%20Delivery",
+                                "rel": "self"
+                        } ],
+                        "name": "testGeoMap"
+                    },
+                    "status" : {
+                           "changeId": "93a48b86-4fc3-4a5f-9ca2-036835034cc6",
+                           "links": [
+                               {
+                                  "href": "/config-gtm/v1/domains/example.akadns.net/status/current",
+                                  "rel": "self"
+                               }
+                           ],
+                           "message": "Change Pending",
+                           "passingValidation": true,
+                           "propagationStatus": "PENDING",
+                           "propagationStatusDate": "2014-04-15T11:30:27.000+0000"
+                    }
+               }`)
+
+	Init(config)
+
+	testGeoMap := instantiateGeoMap()
+	statresp, err := testGeoMap.Create(gtmTestDomain)
+	assert.NoError(t, err)
+
+	assert.IsType(t, &GeoMap{}, statresp.Resource)
+	assert.Equal(t, GtmTestGeoMap, statresp.Resource.Name)
+
+}
+
+func TestUpdateGeoMap(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/geographic-maps/" + GtmTestGeoMap)
+	mock.
+		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/geographic-maps/"+GtmTestGeoMap).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                    "resource" : {
+                        "assignments": [ {
+                                "countries": [ "GB", "IE" ],
+                                "datacenterId": 3133,
+                                "nickname": "UK and Ireland users"
+                        } ],
+                        "defaultDatacenter": {
+                                "datacenterId": 5400,
+                                "nickname": "Default Mapping"
+                        },
+                        "links": [ {
+                                "href": "/config-gtm/v1/domains/example.akadns.net/geographic-maps/UK%20Delivery",
+                                "rel": "self"
+                        } ],
+                        "name": "testGeoMap"
+                    },
+                    "status" : {
+                           "changeId": "93a48b86-4fc3-4a5f-9ca2-036835034cc6",
+                           "links": [
+                               {
+                                  "href": "/config-gtm/v1/domains/example.akadns.net/status/current",
+                                  "rel": "self"
+                               }
+                           ],
+                           "message": "Change Pending",
+                           "passingValidation": true,
+                           "propagationStatus": "PENDING",
+                           "propagationStatusDate": "2014-04-15T11:30:27.000+0000"
+                    }
+               }`)
+
+	Init(config)
+
+	testGeoMap := instantiateGeoMap()
+	_, err := testGeoMap.Update(gtmTestDomain)
+	assert.NoError(t, err)
+
+}
+
+func TestDeleteGeoMap(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/geographic-maps/" + GtmTestGeoMap)
+	mock.
+		Delete("/config-gtm/v1/domains/"+gtmTestDomain+"/geographic-maps/"+GtmTestGeoMap).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                    "resource" : {
+                    },
+                    "status" : {
+                           "changeId": "93a48b86-4fc3-4a5f-9ca2-036835034cc6",
+                           "links": [
+                               {
+                                  "href": "/config-gtm/v1/domains/example.akadns.net/status/current",
+                                  "rel": "self"
+                               }
+                           ],
+                           "message": "Change Pending",
+                           "passingValidation": true,
+                           "propagationStatus": "PENDING",
+                           "propagationStatusDate": "2014-04-15T11:30:27.000+0000"
+                    }
+               }`)
+
+	Init(config)
+
+	getGeoMap := instantiateGeoMap()
+	stat, err := getGeoMap.Delete(gtmTestDomain)
+	assert.NoError(t, err)
+	assert.Equal(t, "93a48b86-4fc3-4a5f-9ca2-036835034cc6", stat.ChangeId)
+
+}

--- a/configgtm-v1_5/geomap_test.go
+++ b/configgtm-v1_5/geomap_test.go
@@ -46,7 +46,7 @@ func TestListGeoMaps(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/geographic-maps").
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                     "items" : [ {
                         "assignments": [ {
@@ -85,7 +85,7 @@ func TestGetGeoMap(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/geographic-maps/"+GtmTestGeoMap).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "assignments": [ {
                                 "countries": [ "GB", "IE" ],
@@ -123,7 +123,7 @@ func TestGetBadGeoMap(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/geographic-maps/"+badName).
 		HeaderPresent("Authorization").
 		Reply(404).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                 }`)
 
@@ -144,7 +144,7 @@ func TestCreateGeoMap(t *testing.T) {
 		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/geographic-maps/"+GtmTestGeoMap).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                     "resource" : {
                         "assignments": [ {
@@ -197,7 +197,7 @@ func TestUpdateGeoMap(t *testing.T) {
 		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/geographic-maps/"+GtmTestGeoMap).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                     "resource" : {
                         "assignments": [ {
@@ -247,7 +247,7 @@ func TestDeleteGeoMap(t *testing.T) {
 		Delete("/config-gtm/v1/domains/"+gtmTestDomain+"/geographic-maps/"+GtmTestGeoMap).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                     "resource" : {
                     },

--- a/configgtm-v1_5/property.go
+++ b/configgtm-v1_5/property.go
@@ -1,0 +1,333 @@
+package configgtm
+
+import (
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
+
+	"fmt"
+)
+
+//
+// Support gtm domain properties thru Edgegrid
+// Based on 1.4 Schema
+//
+
+// TrafficTarget struc
+type TrafficTarget struct {
+	DatacenterId int      `json:"datacenterId"`
+	Enabled      bool     `json:"enabled"`
+	Weight       float64  `json:"weight,omitempty"`
+	Servers      []string `json:"servers,omitempty"`
+	Name         string   `json:"name,omitempty"`
+	HandoutCName string   `json:"handoutCName,omitempty"`
+}
+
+// HttpHeader struc
+type HttpHeader struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type LivenessTest struct {
+	Name                          string        `json:"name"`
+	ErrorPenalty                  float64       `json:"errorPenalty,omitempty"`
+	PeerCertificateVerification   bool          `json:"peerCertificateVerification"`
+	TestInterval                  int           `json:"testInterval,omitempty"`
+	TestObject                    string        `json:"testObject,omitempty"`
+	Links                         []*Link       `json:"links,omitempty"`
+	RequestString                 string        `json:"requestString,omitempty"`
+	ResponseString                string        `json:"responseString,omitempty"`
+	HttpError3xx                  bool          `json:"httpError3xx"`
+	HttpError4xx                  bool          `json:"httpError4xx"`
+	HttpError5xx                  bool          `json:"httpError5xx"`
+	Disabled                      bool          `json:"disabled"`
+	TestObjectProtocol            string        `json:"testObjectProtocol,omitempty"`
+	TestObjectPassword            string        `json:"testObjectPassword,omitempty"`
+	TestObjectPort                int           `json:"testObjectPort,omitempty"`
+	SslClientPrivateKey           string        `json:"sslClientPrivateKey,omitempty"`
+	SslClientCertificate          string        `json:"sslClientCertificate,omitempty"`
+	DisableNonstandardPortWarning bool          `json:"disableNonstandardPortWarning"`
+	HttpHeaders                   []*HttpHeader `json:"httpHeaders,omitempty"`
+	TestObjectUsername            string        `json:"testObjectUsername,omitempty"`
+	TestTimeout                   float32       `json:"testTimeout,omitempty"`
+	TimeoutPenalty                float64       `json:"timeoutPenalty,omitempty"`
+	AnswersRequired               bool          `json:"answersRequired"`
+	ResourceType                  string        `json:"resourceType,omitempty"`
+	RecursionRequested            bool          `json:"recursionRequested"`
+}
+
+// StaticRRSet Struct
+type StaticRRSet struct {
+	Type  string   `json:"type"`
+	TTL   int      `json:"ttl"`
+	Rdata []string `json:"rdata"`
+}
+
+// Property represents a GTM property
+type Property struct {
+	Name                      string           `json:"name"`
+	Type                      string           `json:"type"`
+	Ipv6                      bool             `json:"ipv6"`
+	ScoreAggregationType      string           `json:"scoreAggregationType"`
+	StickinessBonusPercentage int              `json:"stickinessBonusPercentage,omitempty"`
+	StickinessBonusConstant   int              `json:"stickinessBonusConstant,omitempty"`
+	HealthThreshold           float64          `json:"healthThreshold,omitempty"`
+	UseComputedTargets        bool             `json:"useComputedTargets"`
+	BackupIp                  string           `json:"backupIp,omitempty"`
+	BalanceByDownloadScore    bool             `json:"balanceByDownloadScore"`
+	StaticTTL                 int              `json:"staticTTL,omitempty"`
+	StaticRRSets              []*StaticRRSet   `json:"staticRRSets,omitempty"`
+	LastModified              string           `json:"lastModified"`
+	UnreachableThreshold      float64          `json:"unreachableThreshold,omitempty"`
+	MinLiveFraction           float64          `json:"minLiveFraction,omitempty"`
+	HealthMultiplier          float64          `json:"healthMultiplier,omitempty"`
+	DynamicTTL                int              `json:"dynamicTTL,omitempty"`
+	MaxUnreachablePenalty     int              `json:"maxUnreachablePenalty,omitempty"`
+	MapName                   string           `json:"mapName,omitempty"`
+	HandoutLimit              int              `json:"handoutLimit"`
+	HandoutMode               string           `json:"handoutMode"`
+	FailoverDelay             int              `json:"failoverDelay,omitempty"`
+	BackupCName               string           `json:"backupCName,omitempty"`
+	FailbackDelay             int              `json:"failbackDelay,omitempty"`
+	LoadImbalancePercentage   float64          `json:"loadImbalancePercentage,omitempty"`
+	HealthMax                 float64          `json:"healthMax,omitempty"`
+	GhostDemandReporting      bool             `json:"ghostDemandReporting"`
+	Comments                  string           `json:"comments,omitempty"`
+	CName                     string           `json:"cname,omitempty"`
+	WeightedHashBitsForIPv4   int              `json:"weightedHashBitsForIPv4,omitempty"`
+	WeightedHashBitsForIPv6   int              `json:"weightedHashBitsForIPv6,omitempty"`
+	TrafficTargets            []*TrafficTarget `json:"trafficTargets,omitempty"`
+	Links                     []*Link          `json:"links,omitempty"`
+	LivenessTests             []*LivenessTest  `json:"livenessTests,omitempty"`
+}
+
+type PropertyList struct {
+	PropertyItems []*Property `json:"items"`
+}
+
+// NewTrafficTarget is a method applied to a property object that instantiates a TrafficTarget object.
+func (prop *Property) NewTrafficTarget() *TrafficTarget {
+
+	return &TrafficTarget{}
+
+}
+
+// NewStaticRRSet is a method applied to a property object that instantiates a StaticRRSet object.
+func (prop *Property) NewStaticRRSet() *StaticRRSet {
+
+	return &StaticRRSet{}
+
+}
+
+// NewHttpHeader is a method applied to a livenesstest object that instantiates an HttpHeader  object.
+func (lt *LivenessTest) NewHttpHeader() *HttpHeader {
+
+	return &HttpHeader{}
+
+}
+
+// NewLivenessTest is a method applied to a property object that instantiates a LivenessTest object.
+func (prop *Property) NewLivenessTest(name string, objproto string, interval int, timeout float32) *LivenessTest {
+
+	return &LivenessTest{Name: name, TestInterval: interval, TestObjectProtocol: objproto, TestTimeout: timeout}
+
+}
+
+// NewProperty creates a new Property object.
+func NewProperty(name string) *Property {
+	property := &Property{Name: name}
+	return property
+}
+
+// ListProperties retreieves all Properties for the provided domainName.
+func ListProperties(domainName string) ([]*Property, error) {
+	properties := &PropertyList{}
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/properties", domainName),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	printHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, CommonError{entityName: "Domain", name: domainName}
+	} else {
+		err = client.BodyJSON(res, properties)
+		if err != nil {
+			return nil, err
+		}
+
+		return properties.PropertyItems, nil
+	}
+}
+
+// GetProperty retrieves a Property with the given name.
+func GetProperty(name, domainName string) (*Property, error) {
+	property := NewProperty(name)
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/properties/%s", domainName, name),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	printHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, CommonError{entityName: "Property", name: name}
+	} else {
+		err = client.BodyJSON(res, property)
+		if err != nil {
+			return nil, err
+		}
+
+		return property, nil
+	}
+}
+
+// Create the property in the receiver argument in the specified domain.
+func (property *Property) Create(domainName string) (*PropertyResponse, error) {
+
+	// Need do any validation?
+	return property.save(domainName)
+}
+
+// Update the property in the receiver argument in the specified domain.
+func (property *Property) Update(domainName string) (*ResponseStatus, error) {
+
+	// Need do any validation?
+	stat, err := property.save(domainName)
+	if err != nil {
+		return nil, err
+	}
+	return stat.Status, err
+
+}
+
+// Save Property updates method
+func (property *Property) save(domainName string) (*PropertyResponse, error) {
+
+	req, err := client.NewJSONRequest(
+		Config,
+		"PUT",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/properties/%s", domainName, property.Name),
+		property,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+
+	// Network error
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "Property",
+			name:             property.Name,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	printHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "Property", name: property.Name, apiErrorMessage: err.Detail, err: err}
+	}
+
+	responseBody := &PropertyResponse{}
+	// Unmarshall whole response body in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody, nil
+
+}
+
+// Delete the property identified by the receiver argument from the domain provided.
+func (property *Property) Delete(domainName string) (*ResponseStatus, error) {
+
+	req, err := client.NewRequest(
+		Config,
+		"DELETE",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/properties/%s", domainName, property.Name),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Network error
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "Property",
+			name:             property.Name,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	printHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "Property", name: property.Name, apiErrorMessage: err.Detail, err: err}
+	}
+
+	responseBody := &ResponseBody{}
+	// Unmarshall whole response body in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody.Status, nil
+
+}

--- a/configgtm-v1_5/property.go
+++ b/configgtm-v1_5/property.go
@@ -8,7 +8,7 @@ import (
 
 //
 // Support gtm domain properties thru Edgegrid
-// Based on 1.4 Schema
+// Based on 1.5 Schema
 //
 
 // TrafficTarget struc
@@ -53,6 +53,8 @@ type LivenessTest struct {
 	AnswersRequired               bool          `json:"answersRequired"`
 	ResourceType                  string        `json:"resourceType,omitempty"`
 	RecursionRequested            bool          `json:"recursionRequested"`
+	HttpMethod                    string        `json:"httpMethod,omitempty"`
+	HttpRequestBody               string        `json:"httpRequestBody,omitempty"`
 }
 
 // StaticRRSet Struct

--- a/configgtm-v1_5/property_test.go
+++ b/configgtm-v1_5/property_test.go
@@ -1,0 +1,421 @@
+package configgtm
+
+import (
+	"testing"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/jsonhooks-v1"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
+
+	"fmt"
+)
+
+var GtmTestProperty = "testproperty"
+
+func instantiateProperty() *Property {
+
+	property := NewProperty(GtmTestProperty)
+	propertyData := []byte(`{
+                        "backupCName" : null,
+                        "backupIp" : null,
+                        "balanceByDownloadScore" : false,
+                        "cname" : null,
+                        "comments" : null,
+                        "dynamicTTL" : 300,
+                        "failoverDelay" : null,
+                        "failbackDelay" : null,
+                        "ghostDemandReporting" : false,
+                        "handoutMode" : "normal",
+                        "handoutLimit" : 1,
+                        "healthMax" : null,
+                        "healthMultiplier" : null,
+                        "healthThreshold" : null,
+                        "lastModified" : "2019-06-14T19:46:17.818+00:00",
+                        "livenessTests" : [ ],
+                        "loadImbalancePercentage" : null,
+                        "mapName" : null,
+                        "maxUnreachablePenalty" : null,
+                        "minLiveFraction" : null,
+                        "mxRecords" : [ ],
+                        "name" : "testproperty",
+                        "scoreAggregationType" : "median",
+                        "stickinessBonusConstant" : null,
+                        "stickinessBonusPercentage" : null,
+                        "staticTTL" : null,
+                        "trafficTargets" : [ {
+                                "datacenterId" : 3131,
+                                "enabled" : true,
+                                "weight" : 100.0,
+                                "handoutCName" : null,
+                                "name" : null,
+                                "servers" : [ "1.2.3.4" ]
+                        } ],
+                        "type" : "performance",
+                        "unreachableThreshold" : null,
+                        "useComputedTargets" : false,
+                        "weightedHashBitsForIPv4" : null,
+                        "weightedHashBitsForIPv6" : null,
+                        "ipv6" : false,
+                        "links" : [ {
+                                            "rel" : "self",
+                                             "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/properties/testproperty"
+                        } ]
+            }`)
+	jsonhooks.Unmarshal(propertyData, property)
+
+	return property
+
+}
+
+// Verify GetListProperties. Should pass, e.g. no API errors and non nil list.
+func TestListProperties(t *testing.T) {
+
+	defer gock.Off()
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/properties")
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/properties").
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                    "items": [ {
+                        "backupCName" : null,
+                        "backupIp" : null,
+                        "balanceByDownloadScore" : false,
+                        "cname" : null,
+                        "comments" : null,
+                        "dynamicTTL" : 300,
+                        "failoverDelay" : null,
+                        "failbackDelay" : null,
+                        "ghostDemandReporting" : false,
+                        "handoutMode" : "normal",
+                        "handoutLimit" : 1,
+                        "healthMax" : null,
+                        "healthMultiplier" : null,
+                        "healthThreshold" : null,
+                        "lastModified" : "2019-06-14T19:46:17.818+00:00",
+                        "livenessTests" : [ ],
+                        "loadImbalancePercentage" : null,
+                        "mapName" : null,
+                        "maxUnreachablePenalty" : null,
+                        "minLiveFraction" : null,
+                        "mxRecords" : [ ],
+                        "name" : "testproperty",
+                        "scoreAggregationType" : "median",
+                        "stickinessBonusConstant" : null,
+                        "stickinessBonusPercentage" : null,
+                        "staticTTL" : null,
+                        "trafficTargets" : [ {
+                                "datacenterId" : 3131,
+                                "enabled" : true,
+                                "weight" : 100.0,
+                                "handoutCName" : null,
+                                "name" : null,
+                                "servers" : [ "1.2.3.4" ]
+                        } ],
+                        "type" : "performance",
+                        "unreachableThreshold" : null,
+                        "useComputedTargets" : false,
+                        "weightedHashBitsForIPv4" : null,
+                        "weightedHashBitsForIPv6" : null,
+                        "ipv6" : false,
+                        "links" : [ {
+                                            "rel" : "self",
+                                            "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/properties/testproperty"
+                        } ] 
+                    } ]
+                }`)
+
+	Init(config)
+
+	propertyList, err := ListProperties(gtmTestDomain)
+	assert.NoError(t, err)
+	assert.NotEqual(t, propertyList, nil)
+
+	if len(propertyList) > 0 {
+		firstProp := propertyList[0]
+		assert.Equal(t, firstProp.Name, GtmTestProperty)
+	} else {
+		assert.Equal(t, 0, 1, "ListProperties: empty list")
+		fmt.Println("ListProperties: empty list")
+	}
+
+}
+
+// Verify GetProperty. Name hardcoded. Should pass, e.g. no API errors and property returned
+// Depends on CreateProperty
+func TestGetProperty(t *testing.T) {
+
+	defer gock.Off()
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/properties/" + GtmTestProperty)
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/properties/"+GtmTestProperty).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "backupCName" : null,
+                        "backupIp" : null,
+                        "balanceByDownloadScore" : false,
+                        "cname" : null,
+                        "comments" : null,
+                        "dynamicTTL" : 300,
+                        "failoverDelay" : null,
+                        "failbackDelay" : null,
+                        "ghostDemandReporting" : false,
+                        "handoutMode" : "normal",
+                        "handoutLimit" : 1,
+                        "healthMax" : null,
+                        "healthMultiplier" : null,
+                        "healthThreshold" : null,
+                        "lastModified" : "2019-06-14T19:46:17.818+00:00",
+                        "livenessTests" : [ ],
+                        "loadImbalancePercentage" : null,
+                        "mapName" : null,
+                        "maxUnreachablePenalty" : null,
+                        "minLiveFraction" : null,
+                        "mxRecords" : [ ],
+                        "name" : "testproperty",
+                        "scoreAggregationType" : "median",
+                        "stickinessBonusConstant" : null,
+                        "stickinessBonusPercentage" : null,
+                        "staticTTL" : null,
+                        "trafficTargets" : [ {
+                                "datacenterId" : 3131,
+                                "enabled" : true,
+                                "weight" : 100.0,
+                                "handoutCName" : null,
+                                "name" : null,
+                                "servers" : [ "1.2.3.4" ]
+                        } ],
+                        "type" : "performance",
+                        "unreachableThreshold" : null,
+                        "useComputedTargets" : false,
+                        "weightedHashBitsForIPv4" : null,
+                        "weightedHashBitsForIPv6" : null,
+                        "ipv6" : false,
+                        "links" : [ {
+                                            "rel" : "self",
+                                            "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/properties/testproperty"
+                        } ]
+               }`)
+
+	Init(config)
+
+	testProperty, err := GetProperty(GtmTestProperty, gtmTestDomain)
+
+	assert.NoError(t, err)
+	assert.Equal(t, GtmTestProperty, testProperty.Name)
+
+}
+
+// Verify failed case for GetProperty. Should pass, e.g. no API errors and domain not found
+func TestGetBadProperty(t *testing.T) {
+
+	boguspropertyname := "boguspropertyname"
+	defer gock.Off()
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/properties/" + boguspropertyname)
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/properties/"+boguspropertyname).
+		HeaderPresent("Authorization").
+		Reply(404).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+               }`)
+	Init(config)
+
+	_, err := GetProperty("boguspropertyname", gtmTestDomain)
+	assert.Error(t, err)
+
+}
+
+// Test Create property. Name is hardcoded so this will effectively be an update. What happens to existing?
+func TestCreateProperty(t *testing.T) {
+
+	defer gock.Off()
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/properties/" + GtmTestProperty)
+	mock.
+		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/properties/"+GtmTestProperty).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                    "resource" : {
+                        "backupCName" : null,
+                        "backupIp" : null,
+                        "balanceByDownloadScore" : false,
+                        "cname" : null,
+                        "comments" : null,
+                        "dynamicTTL" : 300,
+                        "failoverDelay" : null,
+                        "failbackDelay" : null,
+                        "ghostDemandReporting" : false,
+                        "handoutMode" : "normal",
+                        "handoutLimit" : 1,
+                        "healthMax" : null,
+                        "healthMultiplier" : null,
+                        "healthThreshold" : null,
+                        "lastModified" : "2019-06-14T19:46:17.818+00:00",
+                        "livenessTests" : [ ],
+                        "loadImbalancePercentage" : null,
+                        "mapName" : null,
+                        "maxUnreachablePenalty" : null,
+                        "minLiveFraction" : null,
+                        "mxRecords" : [ ],
+                        "name" : "testproperty",
+                        "scoreAggregationType" : "median",
+                        "stickinessBonusConstant" : null,
+                        "stickinessBonusPercentage" : null,
+                        "staticTTL" : null,
+                        "trafficTargets" : [ {
+                                "datacenterId" : 3131,
+                                "enabled" : true,
+                                "weight" : 100.0,
+                                "handoutCName" : null,
+                                "name" : null, 
+                                "servers" : [ "1.2.3.4" ]
+                        } ],    
+                            "type" : "performance",
+                        "unreachableThreshold" : null,
+                        "useComputedTargets" : false,
+                        "weightedHashBitsForIPv4" : null,
+                        "weightedHashBitsForIPv6" : null,
+                        "ipv6" : false,
+                        "links" : [ {
+                                            "rel" : "self",
+                                             "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/properties/testproperty"
+                        } ]
+                    },
+                    "status" : {
+                        "message" : "Change Pending",
+                        "changeId" : "ca4ca7a9-2b87-4f7c-8ba6-0cb1571df325",
+                        "propagationStatus" : "PENDING",
+                        "propagationStatusDate" : "2019-06-14T19:46:18.461+00:00",
+                        "passingValidation" : true,
+                        "links" : [ {
+                                            "rel" : "self",
+                                            "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current"
+                        } ]
+                    }
+       }`)
+
+	Init(config)
+
+	// initialize required fields
+	testProperty := NewProperty(GtmTestProperty)
+	testProperty.ScoreAggregationType = "median"
+	testProperty.Type = "performance"
+	testProperty.HandoutLimit = 1
+	testProperty.HandoutMode = "normal"
+	testProperty.FailoverDelay = 0
+	testProperty.FailbackDelay = 0
+	testProperty.TrafficTargets = []*TrafficTarget{&TrafficTarget{DatacenterId: 3131, Enabled: true, Servers: []string{"1.2.3.4"}, Weight: 100.0}}
+
+	statresp, err := testProperty.Create(gtmTestDomain)
+	assert.NoError(t, err)
+
+	assert.IsType(t, &Property{}, statresp.Resource)
+	assert.Equal(t, GtmTestProperty, statresp.Resource.Name)
+
+}
+
+func TestUpdateProperty(t *testing.T) {
+
+	defer gock.Off()
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/properties/" + GtmTestProperty)
+	mock.
+		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/properties/"+GtmTestProperty).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                    "resource" : {
+                        "backupCName" : null,
+                        "backupIp" : null,
+                        "balanceByDownloadScore" : false,
+                        "cname" : null,
+                        "comments" : null,
+                        "dynamicTTL" : 300,
+                        "failoverDelay" : null,
+                        "failbackDelay" : null,
+                        "ghostDemandReporting" : false,
+                        "handoutMode" : "normal",
+                        "handoutLimit" : 999,
+                        "healthMax" : null,
+                        "healthMultiplier" : null,
+                        "healthThreshold" : null,
+                        "lastModified" : "2019-06-14T19:46:17.818+00:00",
+                        "livenessTests" : [ ],
+                        "loadImbalancePercentage" : null,
+                        "mapName" : null,
+                        "maxUnreachablePenalty" : null,
+                        "minLiveFraction" : null,
+                        "mxRecords" : [ ],
+                        "name" : "testproperty",
+                        "scoreAggregationType" : "median",
+                        "stickinessBonusConstant" : null,
+                        "stickinessBonusPercentage" : null,
+                        "staticTTL" : null,
+                        "trafficTargets" : [ {
+                                "datacenterId" : 3131,
+                                "enabled" : true,
+                                "weight" : 100.0,
+                                "handoutCName" : null,
+                                "name" : null,
+                                "servers" : [ "1.2.3.4" ]
+                        } ],
+                              "type" : "performance",
+                        "unreachableThreshold" : null,
+                        "useComputedTargets" : false,
+                        "weightedHashBitsForIPv4" : null,
+                        "weightedHashBitsForIPv6" : null,
+                        "ipv6" : false,
+                        "links" : [ {
+                                            "rel" : "self",
+                                             "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/properties/testproperty"
+                        } ]
+                    },
+                    "status" : {
+                        "message" : "Change Pending",
+                        "changeId" : "ca4ca7a9-2b87-4f7c-8ba6-0cb1571df325",
+                        "propagationStatus" : "PENDING",
+                        "propagationStatusDate" : "2019-06-14T19:46:18.461+00:00",
+                        "passingValidation" : true,
+                        "links" : [ {
+                                            "rel" : "self",
+                                            "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current"
+                        } ]
+                    } 
+                }`)
+
+	Init(config)
+
+	testProperty := instantiateProperty()
+
+	testProperty.HandoutLimit = 999
+	stat, err := testProperty.Update(gtmTestDomain)
+	assert.NoError(t, err)
+	assert.Equal(t, stat.ChangeId, "ca4ca7a9-2b87-4f7c-8ba6-0cb1571df325")
+
+}
+
+func TestDeleteProperty(t *testing.T) {
+
+	defer gock.Off()
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/properties/" + GtmTestProperty)
+	mock.
+		Delete("/config-gtm/v1/domains/"+gtmTestDomain+"/properties/"+GtmTestProperty).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+               }`)
+	Init(config)
+
+	getProperty := instantiateProperty()
+
+	_, err := getProperty.Delete(gtmTestDomain)
+	assert.NoError(t, err)
+
+}

--- a/configgtm-v1_5/property_test.go
+++ b/configgtm-v1_5/property_test.go
@@ -77,7 +77,7 @@ func TestListProperties(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/properties").
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                     "items": [ {
                         "backupCName" : null,
@@ -153,7 +153,7 @@ func TestGetProperty(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/properties/"+GtmTestProperty).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "backupCName" : null,
                         "backupIp" : null,
@@ -170,7 +170,24 @@ func TestGetProperty(t *testing.T) {
                         "healthMultiplier" : null,
                         "healthThreshold" : null,
                         "lastModified" : "2019-06-14T19:46:17.818+00:00",
-                        "livenessTests" : [ ],
+                        "livenessTests" : [  {
+                            "name": "liveness-1",
+                            "peerCertificateVerification": false,
+                            "testInterval": 30,
+                            "testObject": "/healthz",
+                            "httpError3xx": true,
+                            "httpError4xx": true,
+                            "httpError5xx": true,
+                            "disabled": false,
+                            "testObjectProtocol": "HTTP",
+                            "testObjectPort": 80,
+                            "httpHeaders": [ {
+                                "name": "Host",
+                                "value": "example.com"
+                            } ],
+                            "answersRequired": true,
+                            "httpMethod": "POST"
+                        }  ],
                         "loadImbalancePercentage" : null,
                         "mapName" : null,
                         "maxUnreachablePenalty" : null,
@@ -220,7 +237,7 @@ func TestGetBadProperty(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/properties/"+boguspropertyname).
 		HeaderPresent("Authorization").
 		Reply(404).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                }`)
 	Init(config)
@@ -239,7 +256,7 @@ func TestCreateProperty(t *testing.T) {
 		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/properties/"+GtmTestProperty).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                     "resource" : {
                         "backupCName" : null,
@@ -257,7 +274,24 @@ func TestCreateProperty(t *testing.T) {
                         "healthMultiplier" : null,
                         "healthThreshold" : null,
                         "lastModified" : "2019-06-14T19:46:17.818+00:00",
-                        "livenessTests" : [ ],
+                        "livenessTests" : [  {
+                            "name": "liveness-1",
+                            "peerCertificateVerification": false,
+                            "testInterval": 30,
+                            "testObject": "/healthz",
+                            "httpError3xx": true,
+                            "httpError4xx": true,
+                            "httpError5xx": true,
+                            "disabled": false,
+                            "testObjectProtocol": "HTTP",
+                            "testObjectPort": 80,
+                            "httpHeaders": [ {
+                                "name": "Host",
+                                "value": "example.com"
+                            } ],
+                            "answersRequired": true,
+                            "httpMethod": "POST"
+                        }  ],
                         "loadImbalancePercentage" : null,
                         "mapName" : null,
                         "maxUnreachablePenalty" : null,
@@ -328,7 +362,7 @@ func TestUpdateProperty(t *testing.T) {
 		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/properties/"+GtmTestProperty).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                     "resource" : {
                         "backupCName" : null,
@@ -346,7 +380,24 @@ func TestUpdateProperty(t *testing.T) {
                         "healthMultiplier" : null,
                         "healthThreshold" : null,
                         "lastModified" : "2019-06-14T19:46:17.818+00:00",
-                        "livenessTests" : [ ],
+                        livenessTests" : [  {
+                            "name": "liveness-1",
+                            "peerCertificateVerification": false,
+                            "testInterval": 30,
+                            "testObject": "/healthz",
+                            "httpError3xx": true,
+                            "httpError4xx": true,
+                            "httpError5xx": true,
+                            "disabled": false,
+                            "testObjectProtocol": "HTTP",
+                            "testObjectPort": 80,
+                            "httpHeaders": [ {
+                                "name": "Host",
+                                "value": "example.com"
+                            } ],
+                            "answersRequired": true,
+                            "httpMethod": "POST"
+                        }  ],
                         "loadImbalancePercentage" : null,
                         "mapName" : null,
                         "maxUnreachablePenalty" : null,
@@ -408,7 +459,7 @@ func TestDeleteProperty(t *testing.T) {
 		Delete("/config-gtm/v1/domains/"+gtmTestDomain+"/properties/"+GtmTestProperty).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                }`)
 	Init(config)

--- a/configgtm-v1_5/resource.go
+++ b/configgtm-v1_5/resource.go
@@ -1,0 +1,252 @@
+package configgtm
+
+import (
+	"fmt"
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
+)
+
+//
+// Handle Operations on gtm resources
+// Based on 1.4 schema
+//
+
+// ResourceInstance
+type ResourceInstance struct {
+	DatacenterId         int  `json:"datacenterId"`
+	UseDefaultLoadObject bool `json:"useDefaultLoadObject"`
+	LoadObject
+}
+
+// Resource represents a GTM resource
+type Resource struct {
+	Type                        string              `json:"type"`
+	HostHeader                  string              `json:"hostHeader,omitempty"`
+	LeastSquaresDecay           float64             `json:"leastSquaresDecay,omitempty"`
+	Description                 string              `json:"description,omitempty"`
+	LeaderString                string              `json:"leaderString,omitempty"`
+	ConstrainedProperty         string              `json:"constrainedProperty,omitempty"`
+	ResourceInstances           []*ResourceInstance `json:"resourceInstances,omitempty"`
+	AggregationType             string              `json:"aggregationType,omitempty"`
+	Links                       []*Link             `json:"links,omitempty"`
+	LoadImbalancePercentage     float64             `json:"loadImbalancePercentage,omitempty"`
+	UpperBound                  int                 `json:"upperBound,omitempty"`
+	Name                        string              `json:"name"`
+	MaxUMultiplicativeIncrement float64             `json:"maxUMultiplicativeIncrement,omitempty"`
+	DecayRate                   float64             `json:"decayRate,omitempty"`
+}
+
+// ResourceList is the structure returned by List Resources
+type ResourceList struct {
+	ResourceItems []*Resource `json:"items"`
+}
+
+// NewResourceInstance instantiates a new ResourceInstance.
+func (rsrc *Resource) NewResourceInstance(dcID int) *ResourceInstance {
+
+	return &ResourceInstance{DatacenterId: dcID}
+
+}
+
+// NewResource creates a new Resource object.
+func NewResource(name string) *Resource {
+	resource := &Resource{Name: name}
+	return resource
+}
+
+// ListResources retreieves all Resources in the specified domain.
+func ListResources(domainName string) ([]*Resource, error) {
+	rsrcs := &ResourceList{}
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/resources", domainName),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	printHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, CommonError{entityName: "Resources"}
+	}
+	err = client.BodyJSON(res, rsrcs)
+	if err != nil {
+		return nil, err
+	}
+
+	return rsrcs.ResourceItems, nil
+
+}
+
+// GetResource retrieves a Resource with the given name in the specified domain.
+func GetResource(name, domainName string) (*Resource, error) {
+	rsc := NewResource(name)
+	req, err := client.NewRequest(
+		Config,
+		"GET",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/resources/%s", domainName, name),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	printHttpResponse(res, true)
+
+	if client.IsError(res) && res.StatusCode != 404 {
+		return nil, client.NewAPIError(res)
+	} else if res.StatusCode == 404 {
+		return nil, CommonError{entityName: "Resource", name: name}
+	} else {
+		err = client.BodyJSON(res, rsc)
+		if err != nil {
+			return nil, err
+		}
+
+		return rsc, nil
+	}
+}
+
+// Create the resource identified by the receiver argument in the specified domain.
+func (rsrc *Resource) Create(domainName string) (*ResourceResponse, error) {
+
+	// Use common code. Any specific validation needed?
+
+	return rsrc.save(domainName)
+
+}
+
+// Update the resourceidentified in the receiver argument in the specified domain.
+func (rsrc *Resource) Update(domainName string) (*ResponseStatus, error) {
+
+	// common code
+
+	stat, err := rsrc.save(domainName)
+	if err != nil {
+		return nil, err
+	}
+	return stat.Status, err
+
+}
+
+// Save Resource in given domain. Common path for Create and Update.
+func (rsrc *Resource) save(domainName string) (*ResourceResponse, error) {
+
+	req, err := client.NewJSONRequest(
+		Config,
+		"PUT",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/resources/%s", domainName, rsrc.Name),
+		rsrc,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+
+	// Network error
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "Resource",
+			name:             rsrc.Name,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	printHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "Resource", name: rsrc.Name, apiErrorMessage: err.Detail, err: err}
+	}
+
+	responseBody := &ResourceResponse{}
+	// Unmarshall whole response body for updated entity and in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody, nil
+
+}
+
+// Delete the resource identified in the receiver argument from the specified domain.
+func (rsrc *Resource) Delete(domainName string) (*ResponseStatus, error) {
+
+	req, err := client.NewRequest(
+		Config,
+		"DELETE",
+		fmt.Sprintf("/config-gtm/v1/domains/%s/resources/%s", domainName, rsrc.Name),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	setVersionHeader(req, schemaVersion)
+
+	printHttpRequest(req, true)
+
+	res, err := client.Do(Config, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Network error
+	if err != nil {
+		return nil, CommonError{
+			entityName:       "Resource",
+			name:             rsrc.Name,
+			httpErrorMessage: err.Error(),
+			err:              err,
+		}
+	}
+
+	printHttpResponse(res, true)
+
+	// API error
+	if client.IsError(res) {
+		err := client.NewAPIError(res)
+		return nil, CommonError{entityName: "Resource", name: rsrc.Name, apiErrorMessage: err.Detail, err: err}
+	}
+
+	responseBody := &ResponseBody{}
+	// Unmarshall whole response body in case want status
+	err = client.BodyJSON(res, responseBody)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody.Status, nil
+
+}

--- a/configgtm-v1_5/resource.go
+++ b/configgtm-v1_5/resource.go
@@ -2,12 +2,13 @@ package configgtm
 
 import (
 	"fmt"
+
 	"github.com/akamai/AkamaiOPEN-edgegrid-golang/client-v1"
 )
 
 //
 // Handle Operations on gtm resources
-// Based on 1.4 schema
+// Based on 1.5 schema
 //
 
 // ResourceInstance

--- a/configgtm-v1_5/resource_test.go
+++ b/configgtm-v1_5/resource_test.go
@@ -1,0 +1,322 @@
+package configgtm
+
+import (
+	"testing"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/jsonhooks-v1"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
+)
+
+var GtmTestResource = "testResource"
+
+func instantiateResource() *Resource {
+
+	resource := NewResource("dummy")
+	resourceData := []byte(`{
+                                "aggregationType" : "median",
+                                "constrainedProperty" : null,
+                                "decayRate" : null,
+                                "description" : null,
+                                "hostHeader" : null,
+                                "leaderString" : null,
+                                "leastSquaresDecay" : null,
+                                "loadImbalancePercentage" : null,
+                                "maxUMultiplicativeIncrement" : null,
+                                "name" : "testResource",
+                                "resourceInstances" : [ {
+                                        "loadObject" : "",
+                                        "loadObjectPort" : 0,
+                                        "loadServers" : null,
+                                        "datacenterId" : 3131,
+                                        "useDefaultLoadObject" : false
+                                } ],
+                                "type" : "Download score",
+                                "upperBound" : 0,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/resources/testResource"
+                                } ]
+                       }`)
+	jsonhooks.Unmarshal(resourceData, resource)
+
+	return resource
+
+}
+
+// Verify ListResources. Should pass, e.g. no API errors and non nil list.
+func TestListResources(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/resources")
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/resources").
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "items" : [ {
+                                "aggregationType" : "median",
+                                "constrainedProperty" : null,
+                                "decayRate" : null,
+                                "description" : null,
+                                "hostHeader" : null,
+                                "leaderString" : null,
+                                "leastSquaresDecay" : null,
+                                "loadImbalancePercentage" : null,
+                                "maxUMultiplicativeIncrement" : null,
+                                "name" : "testResource",
+                                "resourceInstances" : [ ],
+                                "type" : "Download score",
+                                "upperBound" : 0,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/resources/testResource"
+                                } ]
+                        } ]
+               }`)
+
+	Init(config)
+	resourceList, err := ListResources(gtmTestDomain)
+	assert.NoError(t, err)
+	assert.NotEqual(t, resourceList, nil)
+
+	if len(resourceList) > 0 {
+		firstResource := resourceList[0]
+		assert.Equal(t, firstResource.Name, GtmTestResource)
+	} else {
+		t.Fatal("List empty!")
+	}
+}
+
+// Depends on CreateResource
+func TestGetResource(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/resources/" + GtmTestResource)
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/resources/"+GtmTestResource).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "aggregationType" : "median",
+                        "constrainedProperty" : null,
+                        "decayRate" : null,
+                        "description" : null,
+                        "hostHeader" : null,
+                        "leaderString" : null,
+                        "leastSquaresDecay" : null,
+                        "loadImbalancePercentage" : null,
+                        "maxUMultiplicativeIncrement" : null,
+                        "name" : "testResource",
+                        "resourceInstances" : [ ],
+                        "type" : "Download score",
+                        "upperBound" : 0,
+                        "links" : [ {
+                                "rel" : "self",
+                                "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/resources/testResource"
+                        } ]
+              }`)
+
+	Init(config)
+
+	testResource, err := GetResource(GtmTestResource, gtmTestDomain)
+	assert.NoError(t, err)
+	assert.IsType(t, &Resource{}, testResource)
+	assert.Equal(t, GtmTestResource, testResource.Name)
+
+}
+
+// Verify failed case for GetResource. Should pass, e.g. no API errors and domain not found
+func TestGetBadResource(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/resources/somebadname")
+	mock.
+		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/resources/somebadname").
+		HeaderPresent("Authorization").
+		Reply(404).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        }`)
+
+	Init(config)
+
+	_, err := GetResource("somebadname", gtmTestDomain)
+	// Shouldn't have found
+	assert.Error(t, err)
+
+}
+
+// Test Create resource.
+func TestCreateResource(t *testing.T) {
+
+	defer gock.Off()
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/resources/" + GtmTestResource)
+	mock.
+		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/resources/"+GtmTestResource).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "resource" : {
+                                "aggregationType" : "median",
+                                "constrainedProperty" : null,
+                                "decayRate" : null,
+                                "description" : null,
+                                "hostHeader" : null,
+                                "leaderString" : null,
+                                "leastSquaresDecay" : null,
+                                "loadImbalancePercentage" : null,
+                                "maxUMultiplicativeIncrement" : null,
+                                "name" : "testResource",
+                                "resourceInstances" : [ {
+                                        "loadObject" : "",
+                                        "loadObjectPort" : 0,
+                                        "loadServers" : null,
+                                        "datacenterId" : 3131,
+                                        "useDefaultLoadObject" : false
+                                } ],
+                                "type" : "Download score",
+                                "upperBound" : 0,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/resources/testResource"
+                                } ]
+                        },
+                        "status" : {
+                                "message" : "Change Pending",
+                                "changeId" : "5bb9f131-99c8-43ff-afd2-a6ce34db8b95",
+                                "propagationStatus" : "PENDING",
+                                "propagationStatusDate" : "2019-06-17T17:54:37.383+00:00",
+                                "passingValidation" : true,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current"
+                                } ]
+                        }
+                }`)
+
+	Init(config)
+
+	testResource := NewResource(GtmTestResource)
+	testResource.AggregationType = "median"
+	testResource.Type = "Download score"
+
+	// Create a Resource Instance
+	var instanceSlice []*ResourceInstance
+	instance := testResource.NewResourceInstance(3131)
+	instanceSlice = append(instanceSlice, instance)
+	testResource.ResourceInstances = instanceSlice
+
+	// do the create
+
+	statresp, err := testResource.Create(gtmTestDomain)
+	assert.NoError(t, err)
+
+	assert.IsType(t, &Resource{}, statresp.Resource)
+	assert.Equal(t, GtmTestResource, statresp.Resource.Name)
+
+}
+
+func TestUpdateResource(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/resources/" + GtmTestResource)
+	mock.
+		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/resources/"+GtmTestResource).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "resource" : {
+                                "aggregationType" : "median",
+                                "constrainedProperty" : null,
+                                "decayRate" : 0.5,
+                                "description" : null,
+                                "hostHeader" : null,
+                                "leaderString" : null,
+                                "leastSquaresDecay" : null,
+                                "loadImbalancePercentage" : null,
+                                "maxUMultiplicativeIncrement" : null,
+                                "name" : "testResource",
+                                "resourceInstances" : [ {
+                                        "loadObject" : "",
+                                        "loadObjectPort" : 0,
+                                        "loadServers" : null,
+                                        "datacenterId" : 3131,
+                                        "useDefaultLoadObject" : false
+                                } ],
+                                "type" : "Download score",
+                                "upperBound" : 0,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/resources/testResource"
+                                } ]
+                        },
+                        "status" : {
+                                "message" : "Change Pending",
+                                "changeId" : "5bb9f131-99c8-43ff-afd2-a6ce34db8b95",
+                                "propagationStatus" : "PENDING",
+                                "propagationStatusDate" : "2019-06-17T17:54:37.383+00:00",
+                                "passingValidation" : true,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current"
+                                } ]
+                        }
+                }`)
+
+	Init(config)
+
+	testResource := instantiateResource()
+
+	newDecay := 0.5
+	testResource.DecayRate = newDecay
+	stat, err := testResource.Update(gtmTestDomain)
+	assert.NoError(t, err)
+
+	assert.Equal(t, stat.ChangeId, "5bb9f131-99c8-43ff-afd2-a6ce34db8b95")
+
+}
+
+func TestDeleteResource(t *testing.T) {
+
+	defer gock.Off()
+
+	mock := gock.New("https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/config-gtm/v1/domains/" + gtmTestDomain + "/resources/" + GtmTestResource)
+	mock.
+		Delete("/config-gtm/v1/domains/"+gtmTestDomain+"/resources/"+GtmTestResource).
+		HeaderPresent("Authorization").
+		Reply(200).
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		BodyString(`{
+                        "resource" : null,
+                        "status" : {
+                                "message" : "Change Pending",
+                                "changeId" : "9a7a8f84-704b-40de-a903-bcc2728513ac",
+                                "propagationStatus" : "PENDING",
+                                "propagationStatusDate" : "2019-06-14T19:51:02.273+00:00",
+                                "passingValidation" : true,
+                                "links" : [ {
+                                        "rel" : "self",
+                                        "href" : "https://akaa-32qkzqewderdchot-d3uwbyqc4pqi2c5l.luna-dev.akamaiapis.net/config-gtm/v1/domains/gtmdomtest.akadns.net/status/current"
+                                 } ]
+                        }
+               }`)
+
+	Init(config)
+
+	getResource := instantiateResource()
+	stat, err := getResource.Delete(gtmTestDomain)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "9a7a8f84-704b-40de-a903-bcc2728513ac", stat.ChangeId)
+
+}

--- a/configgtm-v1_5/resource_test.go
+++ b/configgtm-v1_5/resource_test.go
@@ -55,7 +55,7 @@ func TestListResources(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/resources").
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "items" : [ {
                                 "aggregationType" : "median",
@@ -101,7 +101,7 @@ func TestGetResource(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/resources/"+GtmTestResource).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "aggregationType" : "median",
                         "constrainedProperty" : null,
@@ -141,7 +141,7 @@ func TestGetBadResource(t *testing.T) {
 		Get("/config-gtm/v1/domains/"+gtmTestDomain+"/resources/somebadname").
 		HeaderPresent("Authorization").
 		Reply(404).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         }`)
 
@@ -162,7 +162,7 @@ func TestCreateResource(t *testing.T) {
 		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/resources/"+GtmTestResource).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "resource" : {
                                 "aggregationType" : "median",
@@ -233,7 +233,7 @@ func TestUpdateResource(t *testing.T) {
 		Put("/config-gtm/v1/domains/"+gtmTestDomain+"/resources/"+GtmTestResource).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "resource" : {
                                 "aggregationType" : "median",
@@ -295,7 +295,7 @@ func TestDeleteResource(t *testing.T) {
 		Delete("/config-gtm/v1/domains/"+gtmTestDomain+"/resources/"+GtmTestResource).
 		HeaderPresent("Authorization").
 		Reply(200).
-		SetHeader("Content-Type", "application/vnd.config-gtm.v1.4+json;charset=UTF-8").
+		SetHeader("Content-Type", "application/vnd.config-gtm.v1.5+json;charset=UTF-8").
 		BodyString(`{
                         "resource" : null,
                         "status" : {

--- a/configgtm-v1_5/service.go
+++ b/configgtm-v1_5/service.go
@@ -1,0 +1,34 @@
+package configgtm
+
+import (
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid"
+	"net/http"
+)
+
+var (
+	// Config contains the Akamai OPEN Edgegrid API credentials
+	// for automatic signing of requests
+	Config edgegrid.Config
+)
+
+// Init sets the GTM edgegrid Config
+func Init(config edgegrid.Config) {
+
+	Config = config
+	edgegrid.SetupLogging()
+
+}
+
+// Utility func to print http req
+func printHttpRequest(req *http.Request, body bool) {
+
+	edgegrid.PrintHttpRequest(req, body)
+
+}
+
+// Utility func to print http response
+func printHttpResponse(res *http.Response, body bool) {
+
+	edgegrid.PrintHttpResponse(res, body)
+
+}


### PR DESCRIPTION
This PR is to add the support of the v1.5 GTM API.

Commit https://github.com/akamai/AkamaiOPEN-edgegrid-golang/pull/132/commits/322451b49f08b03785f7a2712340450949fcb4f0 is only to copy v1.4 directory to the new v1.5 directory as is.

Commit https://github.com/akamai/AkamaiOPEN-edgegrid-golang/pull/132/commits/75d5feaa00e59a572e394b44a1fd51adc54062e5 implements the actual changes in the new v1.5 directory according to the v1.5 API
