### PR TITLE
Access Control Group attributes added to Create and Update Network Lists

### DIFF
--- a/pkg/networklists/network_list.go
+++ b/pkg/networklists/network_list.go
@@ -96,19 +96,25 @@ type (
 	}
 
 	CreateNetworkListRequest struct {
-		Name        string   `json:"name"`
-		Type        string   `json:"type"`
-		Description string   `json:"description"`
-		List        []string `json:"list"`
+		Name               string   `json:"name"`
+		Type               string   `json:"type"`
+		Description        string   `json:"description"`
+		List               []string `json:"list"`
+		Group              int      `json:"groupId,omitempty"`
+		Contract           string   `json:"contractId,omitempty"`
+		AccessControlGroup string   `json:"accessControlGroup,omitempty"`
 	}
 
 	UpdateNetworkListRequest struct {
-		Name        string   `json:"name"`
-		Type        string   `json:"type"`
-		Description string   `json:"description"`
-		SyncPoint   int      `json:"syncPoint"`
-		List        []string `json:"list"`
-		UniqueID    string   `json:"uniqueId"`
+		Name               string   `json:"name"`
+		Type               string   `json:"type"`
+		Description        string   `json:"description"`
+		SyncPoint          int      `json:"syncPoint"`
+		List               []string `json:"list"`
+		UniqueID           string   `json:"uniqueId"`
+		Group              int      `json:"groupId,omitempty"`
+		Contract           string   `json:"contractId,omitempty"`
+		AccessControlGroup string   `json:"accessControlGroup,omitempty"`
 	}
 
 	UpdateNetworkListResponse struct {


### PR DESCRIPTION
Three optional parameters added to leverage group assignments for Network Lists:
```json
Group              int      `json:"groupId,omitempty"`
Contract           string   `json:"contractId,omitempty"`
AccessControlGroup string   `json:"accessControlGroup,omitempty"`
```
It kinda reveals undocumented functionality with updating ACG from a specific one to the top-level one when both Unique ID and an updated ACG specified in Update.