### PR TITLE
update endpoints-v2 > endpoints.go > UpdateEndpointFromFile to update host by default (by adding query param force=true) if the host list change in swagger

### DIFF
--- a/api-endpoints-v2/endpoints.go
+++ b/api-endpoints-v2/endpoints.go
@@ -109,7 +109,7 @@ type UpdateEndpointFromFileOptions struct {
 
 func UpdateEndpointFromFile(options *UpdateEndpointFromFileOptions) (*Endpoint, error) {
 	url := fmt.Sprintf(
-		"/api-definitions/v2/endpoints/%d/versions/%d/file",
+		"/api-definitions/v2/endpoints/%d/versions/%d/file?force=true",
 		options.EndpointId,
 		options.Version,
 	)


### PR DESCRIPTION
This fix is to enable force update by default in order to update hostname within API gateway settings using cli-api-gateway "import" command to update exisisting API endpoint - https://github.com/akamai/cli-api-gateway.
Currently, the "import" command does not update the hostname (inside JSON property "apiEndPointHosts")

**Before the change**
Let say, current API gateway setting as follows:
```
{
"apiEndPointHosts": [
www.test.com
],
"apiEndPointId": 123456,
"apiEndPointName": "PetStore",
"apiEndPointScheme": "http",
...
...
```

File: swagger.yaml
```
openapi: 3.0.1
info:
  title: OpenAPI definition
  version: v0
servers:
- url: http://www.test.com/api
- url: http://api.test.com/api
  description: Generated server url
paths:
..
...
```
Running the following command to update the endpoint in v2
```
$akamai api-gateway import --format swagger --file swagger.yaml --endpoint 123456 --version 2 --json
Importing API endpoint...... [OK]
{
"apiEndPointHosts": [
"www.test.com"
],
"apiEndPointId": 123456,
"apiEndPointName": "Test",
"apiEndPointScheme": "http",
...
...
```

Result: "apiEndPointHosts" didn't get updated


**After the change:**
Running the following command to update the endpoint in v2
```
$akamai api-gateway import --format swagger --file swagger.yaml --endpoint 123456 --version 2 --json
Importing API endpoint...... [OK]
{
"apiEndPointHosts": [
"www.test.com",
"api.test.com"
],
"apiEndPointId": 123456,
"apiEndPointName": "Test",
"apiEndPointScheme": "http",
...
...
```

Result: "apiEndPointHosts" get updated with new hostname
