### PR TITLE
adding support for a flag to permit duplicate cn values.

### DIFF
--- a/cps-v2/enrollments.go
+++ b/cps-v2/enrollments.go
@@ -33,9 +33,10 @@ type Enrollment struct {
 }
 
 type CreateEnrollmentQueryParams struct {
-	ContractID      string
-	DeployNotAfter  *string
-	DeployNotBefore *string
+	AllowDuplicateCN bool
+	ContractID       string
+	DeployNotAfter   *string
+	DeployNotBefore  *string
 }
 
 type ListEnrollmentsQueryParams struct {
@@ -75,6 +76,13 @@ func (enrollment *Enrollment) Create(params CreateEnrollmentQueryParams) (*Creat
 			"%s&deploy-not-before=%s",
 			request,
 			*params.DeployNotBefore,
+		)
+	}
+
+	if params.AllowDuplicateCN {
+		request = fmt.Sprintf(
+			"%s&allow-duplicate-cn=true",
+			request,
 		)
 	}
 


### PR DESCRIPTION
This library's cps-v2 does not currently support creating an enrollment when an existing certificate with a matching cn is found.  
The Akamai CPS enrollments api has support for a flag to allow this.  While it is typically not needed, but there are cases where it is.  For example, a company migrating from VIP certs to SNI certs might want the current cert to remain active and have a new cert issued. They could then perform a slot swap at a later point to allow for a seamless transition.  While the api docs do not currently reflect this flag (a separate gap), it is a valid/supported option that is already in place. I've verified that passing the option is accepted and works.  The akamai cps cli plugin already leverages this same option. 