### PR TITLE
fix: thirdParty validation rejects false

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/akamai/AkamaiOPEN-edgegrid-golang/v2
+module github.com/oops-dan-git/AkamaiOPEN-edgegrid-golang/v2
 
 go 1.17
 

--- a/pkg/cps/enrollments.go
+++ b/pkg/cps/enrollments.go
@@ -245,7 +245,7 @@ func (c CSR) Validate() error {
 // Validate performs validation on ThirdParty
 func (t ThirdParty) Validate() error {
 	return validation.Errors{
-		"excludeSans": validation.Validate(t.ExcludeSANS, validation.Required),
+		"excludeSans": validation.Validate(t.ExcludeSANS, validation.NotNil),
 	}.Filter()
 }
 


### PR DESCRIPTION
The ThirdParty.ExcludeSANS validation currently fails if a value of false is provided.  
This is expected with Required set as the validation type: https://github.com/go-ozzo/ozzo-validation/blob/master/required.go#L14-L17
But since false is a valid option for ExcludeSANS, NotNil is a more appropriate validation type:
https://github.com/go-ozzo/ozzo-validation/blob/master/not_nil.go#L13