### PR TITLE
[fix] fix code errors in documentation examples

### DIFF
--- a/pkg/edgegrid/README.md
+++ b/pkg/edgegrid/README.md
@@ -30,9 +30,7 @@ func main() {
 
     req, _ := http.NewRequest(http.MethodGet, "/papi/v1/contracts", nil)
 
-    if err := edgerc.Sign(r); err != nil {
-        log.Fatalln(err)
-    }
+	edgerc.SignRequest(req)
 
     resp, err := client.Do(req)
     if err != nil {

--- a/pkg/edgegrid/README.md
+++ b/pkg/edgegrid/README.md
@@ -30,7 +30,7 @@ func main() {
 
     req, _ := http.NewRequest(http.MethodGet, "/papi/v1/contracts", nil)
 
-	edgerc.SignRequest(req)
+    edgerc.SignRequest(req)
 
     resp, err := client.Do(req)
     if err != nil {


### PR DESCRIPTION
在 pkg/edgegrid 的README.md中的Basic Example

    if err := edgerc.Sign(r); err != nil {
        log.Fatalln(err)            
    }
change into

edgerc.SignRequest(req)

Because there is no Sign method in the original code, the Sign method is replaced by SignRequest