### PR TITLE
DXE-2127 [fix]fix：Clean up redundant code

### DIFF
--- a/pkg/edgegrid/config.go
+++ b/pkg/edgegrid/config.go
@@ -196,8 +196,6 @@ func (c *Config) FromEnv(section string) error {
 		}
 	}
 
-	c.MaxBody = 0
-
 	val := os.Getenv(fmt.Sprintf("%s_%s", prefix, "MAX_BODY"))
 	if i, err := strconv.Atoi(val); err == nil {
 		c.MaxBody = i


### PR DESCRIPTION
Conflict on lines 198 and 206 of /pkg/edgegrid/config.go

In line 198, we have set MaxBody to 0

And we are on line 205, we judge whether MaxBody is less than 0

I think line 198 is redundant, which will invalidate the judgment of line 205, and force MaxBody to MaxBodySize

![image](https://user-images.githubusercontent.com/33065391/211284686-b445225b-fa9f-473a-bdcb-a2fceeee678e.png)

