### PR TITLE
DXE-2891 Release/v7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # EDGEGRID GOLANG RELEASE NOTES
 
+## X.X.X (mmmm dd, 2023)
+
+### FEATURES/ENHANCEMENTS:
+
+* APPSEC
+  * Added Bot Management API Support
+    * Challenge Injection Rules - read, update
+
+### Deprecations
+* Challenge Interceptions Rules has been deprecated
+
 ## 7.0.0 (June 20, 2023)
 
 ### BREAKING CHANGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,20 @@
 * APPSEC
   * Added Bot Management API Support
     * Challenge Injection Rules - read, update
+    * Add `CreateSecurityPolicyWithDefaultProtections` method to the `SecurityPolicy` interface to support creating a security policy with all available protections enabled.
 
 ### Deprecations
 * Challenge Interceptions Rules has been deprecated
+* Deprecate the following interfaces used to maintain individual policy protections:
+  * `ApiConstraintsProtection`
+  * `IPGeoProtection`
+  * `MalwareProtection`
+  * `NetworkLayerProtection`
+  * `RateProtection`
+  * `ReputationProtection`
+  * `SlowPostProtection`
+  * `WAFProtection`
+* Deprecate the `CreateSecurityPolicy` method of the `SecurityPolicy` interface.
 
 ## 7.0.0 (June 20, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # EDGEGRID GOLANG RELEASE NOTES
 
-## X.X.X (mmmm dd, 2023)
+## 7.1.0 (July 25, 2023)
 
 ### FEATURES/ENHANCEMENTS:
 
@@ -8,8 +8,10 @@
   * Added Bot Management API Support
     * Challenge Injection Rules - read, update
     * Add `CreateSecurityPolicyWithDefaultProtections` method to the `SecurityPolicy` interface to support creating a security policy with all available protections enabled.
+  * Update marshaling of PII learning setting
 
 ### Deprecations
+
 * Challenge Interceptions Rules has been deprecated
 * Deprecate the following interfaces used to maintain individual policy protections:
   * `ApiConstraintsProtection`

--- a/pkg/appsec/api_constraints_protection.go
+++ b/pkg/appsec/api_constraints_protection.go
@@ -10,13 +10,16 @@ import (
 
 type (
 	// The ApiConstraintsProtection interface supports retrieving and updating API request constraints protection for a configuration and policy.
+	// Deprecated: this interface will be removed in a future release. Use the SecurityPolicy interface instead.
 	ApiConstraintsProtection interface {
 		// GetAPIConstraintsProtection retrieves the current API constraints protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the GetPolicyProtections method of the PolicyProtections interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/get-policy-protections
 		GetAPIConstraintsProtection(ctx context.Context, params GetAPIConstraintsProtectionRequest) (*GetAPIConstraintsProtectionResponse, error)
 
 		// UpdateAPIConstraintsProtection updates the API constraints protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the CreateSecurityPolicyWithDefaultProtections method of the SecurityPolicy interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/put-policy-protections
 		UpdateAPIConstraintsProtection(ctx context.Context, params UpdateAPIConstraintsProtectionRequest) (*UpdateAPIConstraintsProtectionResponse, error)

--- a/pkg/appsec/export_configuration.go
+++ b/pkg/appsec/export_configuration.go
@@ -774,6 +774,7 @@ type (
 		CustomDenyActions          []map[string]interface{} `json:"customDenyActions,omitempty"`
 		ServeAlternateActions      []map[string]interface{} `json:"serveAlternateActions,omitempty"`
 		ChallengeInterceptionRules map[string]interface{}   `json:"challengeInterceptionRules,omitempty"`
+		ChallengeInjectionRules    map[string]interface{}   `json:"challengeInjectionRules,omitempty"`
 	}
 
 	// BotManagement is returned as part of GetExportConfigurationResponse

--- a/pkg/appsec/export_configuration.go
+++ b/pkg/appsec/export_configuration.go
@@ -507,7 +507,7 @@ type (
 		} `json:"prefetch"`
 		PragmaHeader *GetAdvancedSettingsPragmaResponse `json:"pragmaHeader,omitempty"`
 		RequestBody  *RequestBody                       `json:"requestBody,omitempty"`
-		PIILearning  bool                               `json:"piiLearning"`
+		PIILearning  *PIILearningexp                    `json:"piiLearning,omitempty"`
 	}
 
 	// CustomDenyListexp is returned as part of GetExportConfigurationResponse.
@@ -675,6 +675,11 @@ type (
 	// EvasivePathMatchexp contains the EnablePathMatch setting
 	EvasivePathMatchexp struct {
 		EnablePathMatch bool `json:"enabled"`
+	}
+
+	// PIILearningexp contains the PIILearning setting
+	PIILearningexp struct {
+		EnablePIILearning bool `json:"enabled"`
 	}
 
 	// RequestBody is returned as part of GetExportConfigurationResponse.

--- a/pkg/appsec/ip_geo_protection.go
+++ b/pkg/appsec/ip_geo_protection.go
@@ -10,19 +10,22 @@ import (
 
 type (
 	// The IPGeoProtection interface supports retrieving and updating IPGeo protection for a configuration and policy.
+	// Deprecated: this interface will be removed in a future release. Use the SecurityPolicy interface instead.
 	IPGeoProtection interface {
 		// GetIPGeoProtections retrieves the current IPGeo protection protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the GetPolicyProtections method of the PolicyProtections interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/get-policy-protections
-		// Deprecated: this method will be removed in a future release. Use GetIPGeoProtection instead.
 		GetIPGeoProtections(ctx context.Context, params GetIPGeoProtectionsRequest) (*GetIPGeoProtectionsResponse, error)
 
 		// GetIPGeoProtection retrieves the current IPGeo protection protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the GetPolicyProtections method of the PolicyProtections interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/get-policy-protections
 		GetIPGeoProtection(ctx context.Context, params GetIPGeoProtectionRequest) (*GetIPGeoProtectionResponse, error)
 
 		// UpdateIPGeoProtection updates the IPGeo protection protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the CreateSecurityPolicyWithDefaultProtections method of the SecurityPolicy interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/put-policy-protections
 		UpdateIPGeoProtection(ctx context.Context, params UpdateIPGeoProtectionRequest) (*UpdateIPGeoProtectionResponse, error)

--- a/pkg/appsec/malware_protection.go
+++ b/pkg/appsec/malware_protection.go
@@ -10,13 +10,16 @@ import (
 
 type (
 	// The MalwareProtection interface supports retrieving and updating malware protection for a configuration and policy.
+	// Deprecated: this interface will be removed in a future release. Use the SecurityPolicy interface instead.
 	MalwareProtection interface {
 		// GetMalwareProtection retrieves the current malware protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the GetPolicyProtections method of the PolicyProtections interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/get-policy-malware
 		GetMalwareProtection(ctx context.Context, params GetMalwareProtectionRequest) (*GetMalwareProtectionResponse, error)
 
 		// UpdateMalwareProtection updates the malware protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the CreateSecurityPolicyWithDefaultProtections method of the SecurityPolicy interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/put-policy-malware
 		UpdateMalwareProtection(ctx context.Context, params UpdateMalwareProtectionRequest) (*UpdateMalwareProtectionResponse, error)

--- a/pkg/appsec/mocks.go
+++ b/pkg/appsec/mocks.go
@@ -1261,6 +1261,14 @@ func (m *Mock) CreateSecurityPolicy(ctx context.Context, req CreateSecurityPolic
 	return args.Get(0).(*CreateSecurityPolicyResponse), args.Error(1)
 }
 
+func (m *Mock) CreateSecurityPolicyWithDefaultProtections(ctx context.Context, req CreateSecurityPolicyWithDefaultProtectionsRequest) (*CreateSecurityPolicyResponse, error) {
+	args := m.Called(ctx, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*CreateSecurityPolicyResponse), args.Error(1)
+}
+
 func (m *Mock) CreateReputationProfile(ctx context.Context, req CreateReputationProfileRequest) (*CreateReputationProfileResponse, error) {
 	args := m.Called(ctx, req)
 	if args.Get(0) == nil {

--- a/pkg/appsec/network_layer_protection.go
+++ b/pkg/appsec/network_layer_protection.go
@@ -10,27 +10,30 @@ import (
 
 type (
 	// The NetworkLayerProtection interface supports retrieving and updating network layer protection for a configuration and policy.
+	// Deprecated: this interface will be removed in a future release. Use the SecurityPolicy interface instead.
 	NetworkLayerProtection interface {
 		// GetNetworkLayerProtections retrieves the current network layer protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the GetPolicyProtections method of the PolicyProtections interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/get-policy-protections
-		// Deprecated: this method will be removed in a future release. Use GetNetworkLayerProtection instead.
 		GetNetworkLayerProtections(ctx context.Context, params GetNetworkLayerProtectionsRequest) (*GetNetworkLayerProtectionsResponse, error)
 
 		// GetNetworkLayerProtection retrieves the current network layer protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the GetPolicyProtections method of the PolicyProtections interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/get-policy-protections
 		GetNetworkLayerProtection(ctx context.Context, params GetNetworkLayerProtectionRequest) (*GetNetworkLayerProtectionResponse, error)
 
 		// UpdateNetworkLayerProtection updates the network layer protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the CreateSecurityPolicyWithDefaultProtections method of the SecurityPolicy interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/put-policy-protections
 		UpdateNetworkLayerProtection(ctx context.Context, params UpdateNetworkLayerProtectionRequest) (*UpdateNetworkLayerProtectionResponse, error)
 
 		// RemoveNetworkLayerProtection removes network layer protection for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the CreateSecurityPolicyWithDefaultProtections method of the SecurityPolicy interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/put-policy-protections
-		// Deprecated: this method will be removed in a future release. Use UpdateNetworkLayerProtection instead.
 		RemoveNetworkLayerProtection(ctx context.Context, params RemoveNetworkLayerProtectionRequest) (*RemoveNetworkLayerProtectionResponse, error)
 	}
 

--- a/pkg/appsec/rate_protection.go
+++ b/pkg/appsec/rate_protection.go
@@ -10,19 +10,22 @@ import (
 
 type (
 	// The RateProtection interface supports retrieving and updating rate protection for a configuration and policy.
+	// Deprecated: this interface will be removed in a future release. Use the SecurityPolicy interface instead.
 	RateProtection interface {
 		// GetRateProtections retrieves the current rate protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the GetPolicyProtections method of the PolicyProtections interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/get-policy-protections
-		// Deprecated: this method will be removed in a future release. Use GetRateProtection instead.
 		GetRateProtections(ctx context.Context, params GetRateProtectionsRequest) (*GetRateProtectionsResponse, error)
 
 		// GetRateProtection retrieves the current rate protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the GetPolicyProtections method of the PolicyProtections interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/get-policy-protections
 		GetRateProtection(ctx context.Context, params GetRateProtectionRequest) (*GetRateProtectionResponse, error)
 
 		// UpdateRateProtection updates the rate protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the CreateSecurityPolicyWithDefaultProtections method of the SecurityPolicy interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/put-policy-protections
 		UpdateRateProtection(ctx context.Context, params UpdateRateProtectionRequest) (*UpdateRateProtectionResponse, error)

--- a/pkg/appsec/reputation_protection.go
+++ b/pkg/appsec/reputation_protection.go
@@ -10,27 +10,31 @@ import (
 
 type (
 	// The ReputationProtection interface supports retrieving and updating reputation protection for a configuration and policy.
+	// Deprecated: this interface will be removed in a future release. Use the SecurityPolicy interface instead.
 	ReputationProtection interface {
 		// GetReputationProtections retrieves the current reputation protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the GetPolicyProtections method of the PolicyProtections interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/get-policy-protections
 		// Deprecated: this method will be removed in a future release. Use GetReputationProtection instead.
 		GetReputationProtections(ctx context.Context, params GetReputationProtectionsRequest) (*GetReputationProtectionsResponse, error)
 
 		// GetReputationProtection retrieves the current reputation protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the GetPolicyProtections method of the PolicyProtections interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/get-policy-protections
 		GetReputationProtection(ctx context.Context, params GetReputationProtectionRequest) (*GetReputationProtectionResponse, error)
 
 		// UpdateReputationProtection updates the reputation protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the CreateSecurityPolicyWithDefaultProtections method of the SecurityPolicy interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/put-policy-protections
 		UpdateReputationProtection(ctx context.Context, params UpdateReputationProtectionRequest) (*UpdateReputationProtectionResponse, error)
 
 		// RemoveReputationProtection removes reputation protection for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the CreateSecurityPolicyWithDefaultProtections method of the SecurityPolicy interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/put-policy-protections
-		// Deprecated: this method will be removed in a future release. Use UpdateReputationProtection instead.
 		RemoveReputationProtection(ctx context.Context, params RemoveReputationProtectionRequest) (*RemoveReputationProtectionResponse, error)
 	}
 

--- a/pkg/appsec/security_policy_protections.go
+++ b/pkg/appsec/security_policy_protections.go
@@ -71,11 +71,11 @@ type (
 		ApplyAPIConstraints           bool `json:"applyApiConstraints"`
 		ApplyApplicationLayerControls bool `json:"applyApplicationLayerControls"`
 		ApplyBotmanControls           bool `json:"applyBotmanControls"`
+		ApplyMalwareControls          bool `json:"applyMalwareControls"`
 		ApplyNetworkLayerControls     bool `json:"applyNetworkLayerControls"`
 		ApplyRateControls             bool `json:"applyRateControls"`
 		ApplyReputationControls       bool `json:"applyReputationControls"`
 		ApplySlowPostControls         bool `json:"applySlowPostControls"`
-		ApplyMalwareControls          bool `json:"applyMalwareControls"`
 	}
 )
 

--- a/pkg/appsec/security_policy_test.go
+++ b/pkg/appsec/security_policy_test.go
@@ -92,3 +92,87 @@ func TestAppSec_ListSecurityPolicies(t *testing.T) {
 		})
 	}
 }
+
+func TestAppSec_CreateSecurityPolicyWithDefaultProtectionsSuccess(t *testing.T) {
+
+	response := CreateSecurityPolicyResponse{}
+	respData := compactJSON(loadFixtureBytes("testdata/TestSecurityPolicy/CreateSecurityPolicyWithDefaultProtectionsResponse.json"))
+	err := json.Unmarshal([]byte(respData), &response)
+	require.NoError(t, err)
+
+	requestParams := CreateSecurityPolicyWithDefaultProtectionsRequest{
+		ConfigVersion: ConfigVersion{
+			ConfigID: 43253,
+			Version:  15,
+		},
+		PolicyName:   "akamaitools",
+		PolicyPrefix: "AK01",
+	}
+
+	tests := map[string]struct {
+		params           CreateSecurityPolicyWithDefaultProtectionsRequest
+		responseStatus   int
+		responseBody     string
+		expectedMethod   string
+		expectedPath     string
+		expectedResponse *CreateSecurityPolicyResponse
+		withError        error
+		headers          http.Header
+	}{
+		"200 OK": {
+			params: requestParams,
+			headers: http.Header{
+				"Content-Type": []string{"application/json"},
+			},
+			responseStatus:   http.StatusOK,
+			responseBody:     string(respData),
+			expectedMethod:   http.MethodPost,
+			expectedPath:     "/appsec/v1/configs/43253/versions/15/security-policies/protections",
+			expectedResponse: &response,
+		},
+		"500 internal server error": {
+			params:         requestParams,
+			headers:        http.Header{},
+			responseStatus: http.StatusInternalServerError,
+			responseBody: `
+{
+    "type": "internal_error",
+    "title": "Internal Server Error",
+    "detail": "Error creating security policy with default protections",
+    "status": 500
+}`,
+			expectedMethod: http.MethodPost,
+			expectedPath:   "/appsec/v1/configs/43253/versions/15/security-policies/protections",
+			withError: &Error{
+				Type:       "internal_error",
+				Title:      "Internal Server Error",
+				Detail:     "Error creating security policy with default protections",
+				StatusCode: http.StatusInternalServerError,
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				assert.Equal(t, test.expectedMethod, r.Method)
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := mockAPIClient(t, mockServer)
+			_, err := client.CreateSecurityPolicyWithDefaultProtections(
+				session.ContextWithOptions(
+					context.Background(),
+					session.WithContextHeaders(test.headers),
+				),
+				test.params)
+			if test.withError != nil {
+				assert.True(t, errors.Is(err, test.withError), "want: %s; got: %s", test.withError, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/appsec/selected_hostname.go
+++ b/pkg/appsec/selected_hostname.go
@@ -11,7 +11,7 @@ import (
 type (
 	// The SelectedHostname interface supports retrieving and modifying the list of hostnames protected under
 	// a configuration.
-	// Deprecated: this interface will be removed in a future release.  Use the WAPSelectedHostnames interface instead.
+	// Deprecated: this interface will be removed in a future release. Use the WAPSelectedHostnames interface instead.
 	SelectedHostname interface {
 		// GetSelectedHostnames lists the hostnames that the configuration version selects as candidates of protected hostnames,
 		// which you can use in match targets.

--- a/pkg/appsec/slowpost_protection.go
+++ b/pkg/appsec/slowpost_protection.go
@@ -10,19 +10,22 @@ import (
 
 type (
 	// The SlowPostProtection interface supports retrieving and updating slow post protection for a configuration and policy.
+	// Deprecated: this interface will be removed in a future release. Use the SecurityPolicy interface instead.
 	SlowPostProtection interface {
 		// GetSlowPostProtections retrieves the current SLOW post protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the GetPolicyProtections method of the PolicyProtections interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/get-policy-protections
-		// Deprecated: this method will be removed in a future release. Use GetSlowPostProtection instead.
 		GetSlowPostProtections(ctx context.Context, params GetSlowPostProtectionsRequest) (*GetSlowPostProtectionsResponse, error)
 
 		// GetSlowPostProtection retrieves the current SLOW post protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the GetPolicyProtections method of the PolicyProtections interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/get-policy-protections
 		GetSlowPostProtection(ctx context.Context, params GetSlowPostProtectionRequest) (*GetSlowPostProtectionResponse, error)
 
 		// UpdateSlowPostProtection updates the SLOW post protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the CreateSecurityPolicyWithDefaultProtections method of the SecurityPolicy interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/put-policy-protections
 		UpdateSlowPostProtection(ctx context.Context, params UpdateSlowPostProtectionRequest) (*UpdateSlowPostProtectionResponse, error)

--- a/pkg/appsec/testdata/TestExportConfiguration/ExportConfiguration.json
+++ b/pkg/appsec/testdata/TestExportConfiguration/ExportConfiguration.json
@@ -5213,6 +5213,16 @@
                     "innerKey": "innerValueA"
                 }
             },
+            "challengeInjectionRules": {
+                "primitiveKey": "primitiveValueA",
+                "arrayKey": [
+                    "arrayValueA1",
+                    "arrayValueA2"
+                ],
+                "objectKey": {
+                    "innerKey": "innerValueA"
+                }
+            },
             "conditionalActions": [
                 {
                     "actionId": "action_A",

--- a/pkg/appsec/testdata/TestSecurityPolicy/CreateSecurityPolicyWithDefaultProtectionsResponse.json
+++ b/pkg/appsec/testdata/TestSecurityPolicy/CreateSecurityPolicyWithDefaultProtectionsResponse.json
@@ -1,0 +1,6 @@
+{
+  "ConfigID": 43253,
+  "Version": 15,
+  "PolicyID": "AAAA_81230",
+  "PolicyName": "akamaitools"
+}

--- a/pkg/appsec/waf_protection.go
+++ b/pkg/appsec/waf_protection.go
@@ -10,19 +10,22 @@ import (
 
 type (
 	// The WAFProtection interface supports retrieving and updating application layer protection for a configuration and policy.
+	// Deprecated: this interface will be removed in a future release. Use the SecurityPolicy interface instead.
 	WAFProtection interface {
 		// GetWAFProtections retrieves the current WAF protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the GetPolicyProtections method of the PolicyProtections interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/get-policy-protections
-		// Deprecated: this method will be removed in a future release. Use GetWAFProtection instead.
 		GetWAFProtections(ctx context.Context, params GetWAFProtectionsRequest) (*GetWAFProtectionsResponse, error)
 
 		// GetWAFProtection retrieves the current WAF protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the GetPolicyProtections method of the PolicyProtections interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/get-policy-protections
 		GetWAFProtection(ctx context.Context, params GetWAFProtectionRequest) (*GetWAFProtectionResponse, error)
 
 		// UpdateWAFProtection updates the WAF protection setting for a configuration and policy.
+		// Deprecated: this method will be removed in a future release. Use the CreateSecurityPolicyWithDefaultProtections method of the SecurityPolicy interface instead.
 		//
 		// See: https://techdocs.akamai.com/application-security/reference/put-policy-protections
 		UpdateWAFProtection(ctx context.Context, params UpdateWAFProtectionRequest) (*UpdateWAFProtectionResponse, error)

--- a/pkg/botman/botman.go
+++ b/pkg/botman/botman.go
@@ -26,6 +26,7 @@ type (
 		BotEndpointCoverageReport
 		BotManagementSetting
 		ChallengeAction
+		ChallengeInjectionRules
 		ChallengeInterceptionRules
 		ClientSideSecurity
 		ConditionalAction

--- a/pkg/botman/challenge_injection_rules.go
+++ b/pkg/botman/challenge_injection_rules.go
@@ -1,0 +1,114 @@
+package botman
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v7/pkg/edgegriderr"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+)
+
+type (
+	// The ChallengeInjectionRules interface supports retrieving and updating the challenge injection rules for a configuration
+	ChallengeInjectionRules interface {
+		// GetChallengeInjectionRules https://techdocs.akamai.com/bot-manager/reference/get-challenge-injection-rules
+		GetChallengeInjectionRules(ctx context.Context, params GetChallengeInjectionRulesRequest) (map[string]interface{}, error)
+		// UpdateChallengeInjectionRules https://techdocs.akamai.com/bot-manager/reference/put-challenge-injection-rules
+		UpdateChallengeInjectionRules(ctx context.Context, params UpdateChallengeInjectionRulesRequest) (map[string]interface{}, error)
+	}
+
+	// GetChallengeInjectionRulesRequest is used to retrieve challenge injection rules
+	GetChallengeInjectionRulesRequest struct {
+		ConfigID int64
+		Version  int64
+	}
+
+	// UpdateChallengeInjectionRulesRequest is used to modify challenge injection rules
+	UpdateChallengeInjectionRulesRequest struct {
+		ConfigID    int64
+		Version     int64
+		JsonPayload json.RawMessage
+	}
+)
+
+// Validate validates a GetChallengeInjectionRulesRequest.
+func (v GetChallengeInjectionRulesRequest) Validate() error {
+	return edgegriderr.ParseValidationErrors(validation.Errors{
+		"ConfigID": validation.Validate(v.ConfigID, validation.Required),
+		"Version":  validation.Validate(v.Version, validation.Required),
+	})
+}
+
+// Validate validates an UpdateChallengeInjectionRulesRequest.
+func (v UpdateChallengeInjectionRulesRequest) Validate() error {
+	return edgegriderr.ParseValidationErrors(validation.Errors{
+		"ConfigID":    validation.Validate(v.ConfigID, validation.Required),
+		"Version":     validation.Validate(v.Version, validation.Required),
+		"JsonPayload": validation.Validate(v.JsonPayload, validation.Required),
+	})
+}
+
+func (b *botman) GetChallengeInjectionRules(ctx context.Context, params GetChallengeInjectionRulesRequest) (map[string]interface{}, error) {
+	logger := b.Log(ctx)
+	logger.Debug("GetChallengeInjectionRules")
+
+	if err := params.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrStructValidation, err.Error())
+	}
+
+	uri := fmt.Sprintf(
+		"/appsec/v1/configs/%d/versions/%d/response-actions/challenge-injection-rules",
+		params.ConfigID,
+		params.Version)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, uri, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GetChallengeInjectionRules request: %w", err)
+	}
+
+	var result map[string]interface{}
+	resp, err := b.Exec(req, &result)
+	if err != nil {
+		return nil, fmt.Errorf("GetChallengeInjectionRules request failed: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, b.Error(resp)
+	}
+
+	return result, nil
+}
+
+func (b *botman) UpdateChallengeInjectionRules(ctx context.Context, params UpdateChallengeInjectionRulesRequest) (map[string]interface{}, error) {
+	logger := b.Log(ctx)
+	logger.Debug("UpdateChallengeInjectionRules")
+
+	if err := params.Validate(); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrStructValidation, err.Error())
+	}
+
+	putURL := fmt.Sprintf(
+		"/appsec/v1/configs/%d/versions/%d/response-actions/challenge-injection-rules",
+		params.ConfigID,
+		params.Version,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, putURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create UpdateChallengeInjectionRules request: %w", err)
+	}
+
+	var result map[string]interface{}
+	resp, err := b.Exec(req, &result, params.JsonPayload)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateChallengeInjectionRules request failed: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, b.Error(resp)
+	}
+
+	return result, nil
+}

--- a/pkg/botman/challenge_injection_rules_test.go
+++ b/pkg/botman/challenge_injection_rules_test.go
@@ -1,0 +1,205 @@
+package botman
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/akamai/AkamaiOPEN-edgegrid-golang/v7/pkg/session"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test Get ChallengeInjectionRules
+func TestBotman_GetChallengeInjectionRules(t *testing.T) {
+	tests := map[string]struct {
+		params           GetChallengeInjectionRulesRequest
+		responseStatus   int
+		responseBody     string
+		expectedPath     string
+		expectedResponse map[string]interface{}
+		withError        func(*testing.T, error)
+	}{
+		"200 OK": {
+			params: GetChallengeInjectionRulesRequest{
+				ConfigID: 43253,
+				Version:  15,
+			},
+			responseStatus:   http.StatusOK,
+			responseBody:     `{"testKey":"testValue3"}`,
+			expectedPath:     "/appsec/v1/configs/43253/versions/15/response-actions/challenge-injection-rules",
+			expectedResponse: map[string]interface{}{"testKey": "testValue3"},
+		},
+		"500 internal server error": {
+			params: GetChallengeInjectionRulesRequest{
+				ConfigID: 43253,
+				Version:  15,
+			},
+			responseStatus: http.StatusInternalServerError,
+			responseBody: `
+			{
+				"type": "internal_error",
+				"title": "Internal Server Error",
+				"detail": "Error fetching data"
+			}`,
+			expectedPath: "/appsec/v1/configs/43253/versions/15/response-actions/challenge-injection-rules",
+			withError: func(t *testing.T, err error) {
+				want := &Error{
+					Type:       "internal_error",
+					Title:      "Internal Server Error",
+					Detail:     "Error fetching data",
+					StatusCode: http.StatusInternalServerError,
+				}
+				assert.True(t, errors.Is(err, want), "want: %s; got: %s", want, err)
+			},
+		},
+		"Missing ConfigID": {
+			params: GetChallengeInjectionRulesRequest{
+				Version: 15,
+			},
+			withError: func(t *testing.T, err error) {
+				want := ErrStructValidation
+				assert.True(t, errors.Is(err, want), "want: %s; got: %s", want, err)
+				assert.Contains(t, err.Error(), "ConfigID")
+			},
+		},
+		"Missing Version": {
+			params: GetChallengeInjectionRulesRequest{
+				ConfigID: 43253,
+			},
+			withError: func(t *testing.T, err error) {
+				want := ErrStructValidation
+				assert.True(t, errors.Is(err, want), "want: %s; got: %s", want, err)
+				assert.Contains(t, err.Error(), "Version")
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				assert.Equal(t, http.MethodGet, r.Method)
+				w.WriteHeader(test.responseStatus)
+				_, err := w.Write([]byte(test.responseBody))
+				assert.NoError(t, err)
+			}))
+			client := mockAPIClient(t, mockServer)
+			result, err := client.GetChallengeInjectionRules(context.Background(), test.params)
+			if test.withError != nil {
+				test.withError(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedResponse, result)
+		})
+	}
+}
+
+// Test Update ChallengeInjectionRules.
+func TestBotman_UpdateChallengeInjectionRules(t *testing.T) {
+	tests := map[string]struct {
+		params           UpdateChallengeInjectionRulesRequest
+		responseStatus   int
+		responseBody     string
+		expectedPath     string
+		expectedResponse map[string]interface{}
+		withError        func(*testing.T, error)
+	}{
+		"200 Success": {
+			params: UpdateChallengeInjectionRulesRequest{
+				ConfigID:    43253,
+				Version:     15,
+				JsonPayload: json.RawMessage(`{"testKey":"testValue3"}`),
+			},
+			responseStatus:   http.StatusOK,
+			responseBody:     `{"testKey":"testValue3"}`,
+			expectedResponse: map[string]interface{}{"testKey": "testValue3"},
+			expectedPath:     "/appsec/v1/configs/43253/versions/15/response-actions/challenge-injection-rules",
+		},
+		"500 internal server error": {
+			params: UpdateChallengeInjectionRulesRequest{
+				ConfigID:    43253,
+				Version:     15,
+				JsonPayload: json.RawMessage(`{"testKey":"testValue3"}`),
+			},
+			responseStatus: http.StatusInternalServerError,
+			responseBody: `
+			{
+				"type": "internal_error",
+				"title": "Internal Server Error",
+				"detail": "Error updating data"
+			}`,
+			expectedPath: "/appsec/v1/configs/43253/versions/15/response-actions/challenge-injection-rules",
+			withError: func(t *testing.T, err error) {
+				want := &Error{
+					Type:       "internal_error",
+					Title:      "Internal Server Error",
+					Detail:     "Error updating data",
+					StatusCode: http.StatusInternalServerError,
+				}
+				assert.True(t, errors.Is(err, want), "want: %s; got: %s", want, err)
+			},
+		},
+		"Missing ConfigID": {
+			params: UpdateChallengeInjectionRulesRequest{
+				Version:     15,
+				JsonPayload: json.RawMessage(`{"testKey":"testValue3"}`),
+			},
+			withError: func(t *testing.T, err error) {
+				want := ErrStructValidation
+				assert.True(t, errors.Is(err, want), "want: %s; got: %s", want, err)
+				assert.Contains(t, err.Error(), "ConfigID")
+			},
+		},
+		"Missing Version": {
+			params: UpdateChallengeInjectionRulesRequest{
+				ConfigID:    43253,
+				JsonPayload: json.RawMessage(`{"testKey":"testValue3"}`),
+			},
+			withError: func(t *testing.T, err error) {
+				want := ErrStructValidation
+				assert.True(t, errors.Is(err, want), "want: %s; got: %s", want, err)
+				assert.Contains(t, err.Error(), "Version")
+			},
+		},
+		"Missing JsonPayload": {
+			params: UpdateChallengeInjectionRulesRequest{
+				ConfigID: 43253,
+				Version:  15,
+			},
+			withError: func(t *testing.T, err error) {
+				want := ErrStructValidation
+				assert.True(t, errors.Is(err, want), "want: %s; got: %s", want, err)
+				assert.Contains(t, err.Error(), "JsonPayload")
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, test.expectedPath, r.URL.String())
+				assert.Equal(t, http.MethodPut, r.Method)
+				w.WriteHeader(test.responseStatus)
+				if len(test.responseBody) > 0 {
+					_, err := w.Write([]byte(test.responseBody))
+					assert.NoError(t, err)
+				}
+			}))
+			client := mockAPIClient(t, mockServer)
+			result, err := client.UpdateChallengeInjectionRules(
+				session.ContextWithOptions(
+					context.Background()), test.params)
+			if test.withError != nil {
+				test.withError(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedResponse, result)
+		})
+	}
+}

--- a/pkg/botman/challenge_interception_rules.go
+++ b/pkg/botman/challenge_interception_rules.go
@@ -12,20 +12,25 @@ import (
 type (
 	// The ChallengeInterceptionRules interface supports retrieving and updating the challenge interception rules for a
 	// configuration
+	// Deprecated: this interface will be removed in a future release. Use ChallengeInjectionRules instead.
 	ChallengeInterceptionRules interface {
 		// GetChallengeInterceptionRules https://techdocs.akamai.com/bot-manager/reference/get-challenge-interception-rules
+		// Deprecated: this method will be removed in a future release. Use GetChallengeInjectionRules instead.
 		GetChallengeInterceptionRules(ctx context.Context, params GetChallengeInterceptionRulesRequest) (map[string]interface{}, error)
 		// UpdateChallengeInterceptionRules https://techdocs.akamai.com/bot-manager/reference/put-challenge-interception-rules
+		// Deprecated: this method will be removed in a future release. Use UpdateChallengeInjectionRules instead.
 		UpdateChallengeInterceptionRules(ctx context.Context, params UpdateChallengeInterceptionRulesRequest) (map[string]interface{}, error)
 	}
 
 	// GetChallengeInterceptionRulesRequest is used to retrieve challenge interception rules
+	// Deprecated: this struct will be removed in a future release. Use GetChallengeInjectionRulesRequest instead.
 	GetChallengeInterceptionRulesRequest struct {
 		ConfigID int64
 		Version  int64
 	}
 
 	// UpdateChallengeInterceptionRulesRequest is used to modify challenge interception rules
+	// Deprecated: this struct will be removed in a future release. Use UpdateChallengeInjectionRulesRequest instead.
 	UpdateChallengeInterceptionRulesRequest struct {
 		ConfigID    int64
 		Version     int64

--- a/pkg/botman/mocks.go
+++ b/pkg/botman/mocks.go
@@ -183,6 +183,20 @@ func (p *Mock) UpdateChallengeInterceptionRules(ctx context.Context, params Upda
 	}
 	return args.Get(0).(map[string]interface{}), nil
 }
+func (p *Mock) GetChallengeInjectionRules(ctx context.Context, params GetChallengeInjectionRulesRequest) (map[string]interface{}, error) {
+	args := p.Called(ctx, params)
+	if args.Error(1) != nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[string]interface{}), nil
+}
+func (p *Mock) UpdateChallengeInjectionRules(ctx context.Context, params UpdateChallengeInjectionRulesRequest) (map[string]interface{}, error) {
+	args := p.Called(ctx, params)
+	if args.Error(1) != nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[string]interface{}), nil
+}
 func (p *Mock) GetClientSideSecurity(ctx context.Context, params GetClientSideSecurityRequest) (map[string]interface{}, error) {
 	args := p.Called(ctx, params)
 	if args.Error(1) != nil {


### PR DESCRIPTION
## 7.1.0 (July 25, 2023)

### FEATURES/ENHANCEMENTS:

* APPSEC
  * Added Bot Management API Support
    * Challenge Injection Rules - read, update
    * Add `CreateSecurityPolicyWithDefaultProtections` method to the `SecurityPolicy` interface to support creating a security policy with all available protections enabled.
  * Update marshaling of PII learning setting

### Deprecations

* Challenge Interceptions Rules has been deprecated
* Deprecate the following interfaces used to maintain individual policy protections:
  * `ApiConstraintsProtection`
  * `IPGeoProtection`
  * `MalwareProtection`
  * `NetworkLayerProtection`
  * `RateProtection`
  * `ReputationProtection`
  * `SlowPostProtection`
  * `WAFProtection`
* Deprecate the `CreateSecurityPolicy` method of the `SecurityPolicy` interface.
