### PR TITLE
DXE-3547 Release/v7.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,57 +1,11 @@
 # EDGEGRID GOLANG RELEASE NOTES
 
-## 8.0.0 (X X, X)
-
-#### BREAKING CHANGES:
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#### FEATURES/ENHANCEMENTS:
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+## 7.6.1 (February 14, 2024)
 
 #### BUG FIXES:
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+* Edgeworkers
+  * Fixed case when not providing optional `note` field in `ActivateVersion` would cause activation to fail 
 
 ## 7.6.0 (February 8, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # EDGEGRID GOLANG RELEASE NOTES
 
+## 8.0.0 (X X, X)
+
+#### BREAKING CHANGES:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#### FEATURES/ENHANCEMENTS:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#### BUG FIXES:
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 ## 7.6.0 (February 8, 2024)
 
 #### FEATURES/ENHANCEMENTS:

--- a/pkg/edgeworkers/activations.go
+++ b/pkg/edgeworkers/activations.go
@@ -50,7 +50,7 @@ type (
 	ActivateVersion struct {
 		Network ActivationNetwork `json:"network"`
 		Version string            `json:"version"`
-		Note    string            `json:"note"`
+		Note    string            `json:"note,omitempty"`
 	}
 
 	// ActivationNetwork represents available activation network types


### PR DESCRIPTION
## 7.6.1 (February 14, 2024)

#### BUG FIXES:

* Edgeworkers
  * Fixed case when not providing optional `note` field in `ActivateVersion` would cause activation to fail 
